### PR TITLE
Generalizing test amounts and minor refinements

### DIFF
--- a/contracts/vending/VendingMachine.sol
+++ b/contracts/vending/VendingMachine.sol
@@ -10,16 +10,15 @@ import "@thesis/solidity-contracts/contracts/token/IReceiveApproval.sol";
 import "../token/T.sol";
 
 /// @title T token vending machine
-/// @notice Contract implements a special lending protocol to enable KEEP/NU
-///         token holders to wrap their tokens as collateral and borrow T tokens
-///         against that collateral based on the wrap ratio. This will go on
-///         indefinitely and enable NU and KEEP token holders to join T network
-///         without needing to buy or sell any assets. Logistically, anyone
-///         holding NU or KEEP can wrap those assets in order to receive T.
-///         They can also unwrap T in order to go back to the underlying asset.
-///         There is a separate instance of this contract deployed for KEEP
-///         holders and a separate instance of this contract deployed for NU
-///         holders.
+/// @notice Contract implements a special update protocol to enable KEEP/NU
+///         token holders to wrap their tokens and obtain T tokens according 
+///         to a fixed ratio. This will go on indefinitely and enable NU and
+///         KEEP token holders to join T network without needing to buy or
+///         sell any assets. Logistically, anyone holding NU or KEEP can wrap
+///         those assets in order to receive T. They can also unwrap T in
+///         order to go back to the underlying asset. There is a separate 
+///         instance of this contract deployed for KEEP holders and a separate
+///         instance of this contract deployed for NU holders.
 contract VendingMachine is Ownable, IReceiveApproval {
     using SafeERC20 for IERC20;
     using SafeERC20 for T;
@@ -33,8 +32,8 @@ contract VendingMachine is Ownable, IReceiveApproval {
     /// @notice T token contract.
     T public immutable tToken;
 
-    /// @notice The ratio with which T token is borrowed based on the provided
-    ///         token being wrapped (KEEP/NU).
+    /// @notice The ratio with which T token is converted based on the provided
+    ///         token being wrapped (KEEP/NU), expressed in 1e18 precision.
     ///
     ///         When wrapping:
     ///           x [T] = amount [KEEP/NU] * ratio / FLOATING_POINT_DIVISOR
@@ -69,8 +68,8 @@ contract VendingMachine is Ownable, IReceiveApproval {
         ratio = _ratio;
     }
 
-    /// @notice Wraps the given amount of the token (KEEP/NU) as collateral and
-    ///         borrows T token proportionally to the amount being wrapped and
+    /// @notice Wraps the given amount of the token (KEEP/NU) and
+    ///         releases T token proportionally to the amount being wrapped and
     ///         the wrap ratio. The token holder needs to have at least the
     ///         given amount of the wrapped token (KEEP/NU) approved to transfer
     ///         to the Vending Machine before calling this function.
@@ -79,8 +78,8 @@ contract VendingMachine is Ownable, IReceiveApproval {
         _wrap(msg.sender, amount);
     }
 
-    /// @notice Wraps the given amount of the token (KEEP/NU) as collateral and
-    ///         borrows T token proportionally to the amount being wrapped and
+    /// @notice Wraps the given amount of the token (KEEP/NU) and
+    ///         releases T token proportionally to the amount being wrapped and
     ///         the wrap ratio. This is a shortcut to `wrap` function allowing
     ///         to avoid a separate approval transaction. Only KEEP/NU token
     ///         is allowed as a caller, so please call this function via
@@ -105,11 +104,11 @@ contract VendingMachine is Ownable, IReceiveApproval {
         _wrap(from, amount);
     }
 
-    /// @notice Unwraps the given amount of T back to the collateral (KEEP/NU)
+    /// @notice Unwraps the given amount of T back to the legacy token (KEEP/NU)
     ///         based on the wrap ratio. Can only be called by a token holder
     ///         who previously wrapped their tokens. The token holder can not
-    ///         unwrap more tokens than they have originally wrapped. The token
-    ///         holder needs to have at least the given amount of T token
+    ///         unwrap more tokens than they originally wrapped. The token
+    ///         holder needs to have at least the given amount of T tokens
     ///         approved to transfer to the Vending Machine before calling this
     ///         function.
     /// @param amount The amount of T to unwrap back to the collateral (KEEP/NU)

--- a/contracts/vending/VendingMachine.sol
+++ b/contracts/vending/VendingMachine.sol
@@ -61,11 +61,12 @@ contract VendingMachine is Ownable, IReceiveApproval {
     constructor(
         IERC20 _wrappedToken,
         T _tToken,
-        uint256 _ratio
+        uint256 _maxWrappedTokens,
+        uint256 _tTokenAllocation
     ) {
         wrappedToken = _wrappedToken;
         tToken = _tToken;
-        ratio = _ratio;
+        ratio = FLOATING_POINT_DIVISOR * _tTokenAllocation / _maxWrappedTokens;
     }
 
     /// @notice Wraps the given amount of the token (KEEP/NU) and

--- a/contracts/vending/VendingMachine.sol
+++ b/contracts/vending/VendingMachine.sol
@@ -69,6 +69,18 @@ contract VendingMachine is Ownable, IReceiveApproval {
         ratio = FLOATING_POINT_DIVISOR * _tTokenAllocation / _maxWrappedTokens;
     }
 
+    /// @notice The T token amount that's obtained from `_amount` wrapped
+    ///         tokens (KEEP/NU).
+    function conversionToT(uint256 _amount) view public returns (uint256) {
+        return _amount * ratio / FLOATING_POINT_DIVISOR;
+    }
+
+    /// @notice The amount of wrapped tokens (KEEP/NU) than's obtained from
+    ///         `_amount` T tokens.
+    function conversionFromT(uint256 _amount) view public returns (uint256) {
+        return _amount * FLOATING_POINT_DIVISOR / ratio;
+    }
+
     /// @notice Wraps the given amount of the token (KEEP/NU) and
     ///         releases T token proportionally to the amount being wrapped and
     ///         the wrap ratio. The token holder needs to have at least the
@@ -118,9 +130,7 @@ contract VendingMachine is Ownable, IReceiveApproval {
     }
 
     function _wrap(address tokenHolder, uint256 wrappedTokenAmount) internal {
-        uint256 tTokenAmount = (wrappedTokenAmount * ratio) /
-            FLOATING_POINT_DIVISOR;
-
+        uint256 tTokenAmount = conversionToT(wrappedTokenAmount);
         emit Wrapped(tokenHolder, wrappedTokenAmount, tTokenAmount);
 
         wrappedBalance[tokenHolder] += wrappedTokenAmount;
@@ -133,8 +143,7 @@ contract VendingMachine is Ownable, IReceiveApproval {
     }
 
     function _unwrap(address tokenHolder, uint256 tTokenAmount) internal {
-        uint256 wrappedTokenAmount = (tTokenAmount * FLOATING_POINT_DIVISOR) /
-            ratio;
+        uint256 wrappedTokenAmount = conversionFromT(tTokenAmount);
 
         require(
             wrappedBalance[tokenHolder] >= wrappedTokenAmount,

--- a/contracts/vending/VendingMachine.sol
+++ b/contracts/vending/VendingMachine.sol
@@ -11,12 +11,12 @@ import "../token/T.sol";
 
 /// @title T token vending machine
 /// @notice Contract implements a special update protocol to enable KEEP/NU
-///         token holders to wrap their tokens and obtain T tokens according 
+///         token holders to wrap their tokens and obtain T tokens according
 ///         to a fixed ratio. This will go on indefinitely and enable NU and
 ///         KEEP token holders to join T network without needing to buy or
 ///         sell any assets. Logistically, anyone holding NU or KEEP can wrap
 ///         those assets in order to receive T. They can also unwrap T in
-///         order to go back to the underlying asset. There is a separate 
+///         order to go back to the underlying asset. There is a separate
 ///         instance of this contract deployed for KEEP holders and a separate
 ///         instance of this contract deployed for NU holders.
 contract VendingMachine is Ownable, IReceiveApproval {
@@ -66,19 +66,9 @@ contract VendingMachine is Ownable, IReceiveApproval {
     ) {
         wrappedToken = _wrappedToken;
         tToken = _tToken;
-        ratio = FLOATING_POINT_DIVISOR * _tTokenAllocation / _maxWrappedTokens;
-    }
-
-    /// @notice The T token amount that's obtained from `_amount` wrapped
-    ///         tokens (KEEP/NU).
-    function conversionToT(uint256 _amount) view public returns (uint256) {
-        return _amount * ratio / FLOATING_POINT_DIVISOR;
-    }
-
-    /// @notice The amount of wrapped tokens (KEEP/NU) than's obtained from
-    ///         `_amount` T tokens.
-    function conversionFromT(uint256 _amount) view public returns (uint256) {
-        return _amount * FLOATING_POINT_DIVISOR / ratio;
+        ratio =
+            (FLOATING_POINT_DIVISOR * _tTokenAllocation) /
+            _maxWrappedTokens;
     }
 
     /// @notice Wraps the given amount of the token (KEEP/NU) and
@@ -127,6 +117,18 @@ contract VendingMachine is Ownable, IReceiveApproval {
     /// @param amount The amount of T to unwrap back to the collateral (KEEP/NU)
     function unwrap(uint256 amount) external {
         _unwrap(msg.sender, amount);
+    }
+
+    /// @notice The T token amount that's obtained from `_amount` wrapped
+    ///         tokens (KEEP/NU).
+    function conversionToT(uint256 _amount) public view returns (uint256) {
+        return (_amount * ratio) / FLOATING_POINT_DIVISOR;
+    }
+
+    /// @notice The amount of wrapped tokens (KEEP/NU) than's obtained from
+    ///         `_amount` T tokens.
+    function conversionFromT(uint256 _amount) public view returns (uint256) {
+        return (_amount * FLOATING_POINT_DIVISOR) / ratio;
     }
 
     function _wrap(address tokenHolder, uint256 wrappedTokenAmount) internal {

--- a/test/vending/VendingMachine.test.js
+++ b/test/vending/VendingMachine.test.js
@@ -1,14 +1,16 @@
 const { expect } = require("chai")
-const { to1e18, to1ePrecision } = require("../helpers/contract-test-helpers")
+const { to1e18 } = require("../helpers/contract-test-helpers")
 
 describe("VendingMachine", () => {
   let wrappedToken
   let tToken
 
   const floatingPointDivisor = to1e18(1)
-  const tAllocation = to1e18("4500000000")  // 4.5 Billion
-  const maxWrappedTokens = to1e18("1100000000")  // 1.1 Billion
-  const expectedRatio = floatingPointDivisor.mul(tAllocation).div(maxWrappedTokens)
+  const tAllocation = to1e18("4500000000") // 4.5 Billion
+  const maxWrappedTokens = to1e18("1100000000") // 1.1 Billion
+  const expectedRatio = floatingPointDivisor
+    .mul(tAllocation)
+    .div(maxWrappedTokens)
 
   let vendingMachine
 
@@ -71,7 +73,9 @@ describe("VendingMachine", () => {
     context("when token holder has enough wrapped tokens", () => {
       context("when wrapping entire allowance", () => {
         const amount = initialHolderBalance
-        const expectedNewBalance = amount.mul(expectedRatio).div(floatingPointDivisor)
+        const expectedNewBalance = amount
+          .mul(expectedRatio)
+          .div(floatingPointDivisor)
         const expectedRemaining = tAllocation.sub(expectedNewBalance)
         let tx
 
@@ -99,11 +103,9 @@ describe("VendingMachine", () => {
         })
 
         it("should emit Wrapped event", async () => {
-          await expect(tx).to.emit(vendingMachine, "Wrapped").withArgs(
-            tokenHolder.address,
-            amount,
-            expectedNewBalance
-          )
+          await expect(tx)
+            .to.emit(vendingMachine, "Wrapped")
+            .withArgs(tokenHolder.address, amount, expectedNewBalance)
         })
 
         it("should update wrapped balance", async () => {
@@ -115,7 +117,9 @@ describe("VendingMachine", () => {
 
       context("when wrapping part of the allowance", () => {
         const amount = to1e18(1)
-        const expectedNewBalance = amount.mul(expectedRatio).div(floatingPointDivisor)
+        const expectedNewBalance = amount
+          .mul(expectedRatio)
+          .div(floatingPointDivisor)
         const expectedRemaining = tAllocation.sub(expectedNewBalance)
         let tx
 
@@ -145,11 +149,9 @@ describe("VendingMachine", () => {
         })
 
         it("should emit Wrapped event", async () => {
-          await expect(tx).to.emit(vendingMachine, "Wrapped").withArgs(
-            tokenHolder.address,
-            amount,
-            expectedNewBalance
-          )
+          await expect(tx)
+            .to.emit(vendingMachine, "Wrapped")
+            .withArgs(tokenHolder.address, amount, expectedNewBalance)
         })
 
         it("should update wrapped balance", async () => {
@@ -189,7 +191,9 @@ describe("VendingMachine", () => {
 
     context("when called via wrapped token's approveAndCall", () => {
       const amount = to1e18(2)
-      const expectedNewBalance = amount.mul(expectedRatio).div(floatingPointDivisor)
+      const expectedNewBalance = amount
+        .mul(expectedRatio)
+        .div(floatingPointDivisor)
       const expectedRemaining = tAllocation.sub(expectedNewBalance)
       let tx
 
@@ -218,11 +222,9 @@ describe("VendingMachine", () => {
       })
 
       it("should emit Wrapped event", async () => {
-        await expect(tx).to.emit(vendingMachine, "Wrapped").withArgs(
-          tokenHolder.address,
-          amount,
-          expectedNewBalance
-        )
+        await expect(tx)
+          .to.emit(vendingMachine, "Wrapped")
+          .withArgs(tokenHolder.address, amount, expectedNewBalance)
       })
     })
   })
@@ -314,9 +316,10 @@ describe("VendingMachine", () => {
 
       context("when updating part of what was previously wrapped", () => {
         context("when unwrapping entire allowance", () => {
-          
           const tAmount2 = to1e18(2)
-          const wrappedAmount2 = tAmount2.mul(floatingPointDivisor).div(expectedRatio)
+          const wrappedAmount2 = tAmount2
+            .mul(floatingPointDivisor)
+            .div(expectedRatio)
           const allocationLeft = tAllocation.sub(tAmount).add(tAmount2)
           const holderTBalance = tAmount.sub(tAmount2)
           let tx
@@ -343,17 +346,13 @@ describe("VendingMachine", () => {
             )
             expect(
               await wrappedToken.balanceOf(vendingMachine.address)
-            ).to.equal(
-              wrappedAmount.sub(wrappedAmount2)
-            )
+            ).to.equal(wrappedAmount.sub(wrappedAmount2))
           })
 
           it("should emit Unwrapped event", async () => {
-            await expect(tx).to.emit(vendingMachine, "Unwrapped").withArgs(
-              tokenHolder.address,
-              tAmount2,
-              wrappedAmount2
-            )
+            await expect(tx)
+              .to.emit(vendingMachine, "Unwrapped")
+              .withArgs(tokenHolder.address, tAmount2, wrappedAmount2)
           })
 
           it("should update wrapped balance", async () => {
@@ -364,9 +363,10 @@ describe("VendingMachine", () => {
         })
 
         context("when unwrapping part of the allowance", () => {
-
           const tAmount2 = to1e18(1)
-          const wrappedAmount2 = tAmount2.mul(floatingPointDivisor).div(expectedRatio)
+          const wrappedAmount2 = tAmount2
+            .mul(floatingPointDivisor)
+            .div(expectedRatio)
 
           beforeEach(async () => {
             await tToken
@@ -390,17 +390,13 @@ describe("VendingMachine", () => {
             )
             expect(
               await wrappedToken.balanceOf(vendingMachine.address)
-            ).to.equal(
-              wrappedAmount.sub(wrappedAmount2)
-            )
+            ).to.equal(wrappedAmount.sub(wrappedAmount2))
           })
 
           it("should emit Unwrapped event", async () => {
-            await expect(tx).to.emit(vendingMachine, "Unwrapped").withArgs(
-              tokenHolder.address,
-              tAmount2,
-              wrappedAmount2
-            )
+            await expect(tx)
+              .to.emit(vendingMachine, "Unwrapped")
+              .withArgs(tokenHolder.address, tAmount2, wrappedAmount2)
           })
 
           it("should update wrapped balance", async () => {

--- a/test/vending/VendingMachine.test.js
+++ b/test/vending/VendingMachine.test.js
@@ -32,7 +32,8 @@ describe("VendingMachine", () => {
     vendingMachine = await VendingMachine.deploy(
       wrappedToken.address,
       tToken.address,
-      expectedRatio
+      maxWrappedTokens,
+      tAllocation
     )
     await vendingMachine.deployed()
 


### PR DESCRIPTION
This is a small changeset on top of @pdyraga's original PR, which I think is fine. I initially thought there could be some precision problems wrt a different approach but in the end the results were the same with both. 
In this PR, I basically do 4 things:
* Generalize the test amounts, and use more real examples (e.g., 4.5 billion T allocation, expected conversion ratio with decimals up to the max precision, etc). Everything checked out in the original contract, so nothing to see here!
* Update the language to move from borrow/collateral terms to the notion of token upgrade
* Extract public functions for conversion to/from T
* Calculate the ratio in the vending machine constructor from the supply amounts, instead of passing it directly.

Apart from this, I have some general comments that I didn't address here since they require a bit more of discussion:
* Multiplication overflow: at conversion time, multiplying two uint256 can potentially overflow. This is not the case however for our particular case, as all relevant amounts (NU/KEEP token amounts, ration with 1e18 precision) can be expressed under 128 bits. We should address this with some checks, or even better, with more restrictive types.
* Inexact (un)wrapping: For certain combinations of token amounts and conversion ratios, conversions are not exact. See this example:
```python
>>> frac = 10**18
>>> ratio = frac * 45//11
>>> ratio
4090909090909090909
>>> x = 10**18-5
>>> x
999999999999999995
>>> x * ratio // frac
4090909090909090888
>>> y = _
>>> y * frac // ratio
999999999999999994
```
In this example, we want to convert `x` tokens, which results in `y`  T tokens. When we convert `y` back to the original we obtain `x - 1`. My initial suggestion would be that, in the first conversion, even though we have the approval to spend `x` tokens, the vending machine only converts amounts it can convert back exactly (in this case, `x - 1`).  