### PR TITLE
Follow-up: Optimize storage of balance checkpoints in T token contract

### DIFF
--- a/contracts/governance/Checkpoints.sol
+++ b/contracts/governance/Checkpoints.sol
@@ -104,6 +104,7 @@ abstract contract Checkpoints {
     }
 
     /// @notice Change delegation for `delegator` to `delegatee`.
+    // slither-disable-next-line dead-code
     function delegate(address delegator, address delegatee) internal virtual;
 
     /// @notice Moves voting power from one delegate to another
@@ -117,6 +118,8 @@ abstract contract Checkpoints {
     ) internal {
         if (src != dst && amount > 0) {
             if (src != address(0)) {
+                // https://github.com/crytic/slither/issues/960
+                // slither-disable-next-line variable-scope
                 (uint256 oldWeight, uint256 newWeight) = writeCheckpoint(
                     _checkpoints[src],
                     subtract,
@@ -126,6 +129,8 @@ abstract contract Checkpoints {
             }
 
             if (dst != address(0)) {
+                // https://github.com/crytic/slither/issues/959
+                // slither-disable-next-line uninitialized-local
                 (uint256 oldWeight, uint256 newWeight) = writeCheckpoint(
                     _checkpoints[dst],
                     add,
@@ -155,6 +160,7 @@ abstract contract Checkpoints {
 
         if (pos > 0) {
             uint32 fromBlock = decodeBlockNumber(ckpts[pos - 1]);
+            // slither-disable-next-line incorrect-equality
             if (fromBlock == block.number) {
                 ckpts[pos - 1] = encodeCheckpoint(
                     fromBlock,
@@ -214,6 +220,7 @@ abstract contract Checkpoints {
     }
 
     /// @notice Maximum token supply. Defaults to `type(uint96).max` (2^96 - 1)
+    // slither-disable-next-line dead-code
     function maxSupply() internal view virtual returns (uint96) {
         return type(uint96).max;
     }


### PR DESCRIPTION
This PR is a follow-up of #19 and two things are happening here:

- Cleared up slither warnings making `main` build green again,
- Improve checkpoint tests for `mint`, `burn`, and `burnFrom`  according to [this](https://github.com/threshold-network/solidity-contracts/pull/19#discussion_r723682356) comment.

I did not look into @vzotova's [comment](https://github.com/threshold-network/solidity-contracts/pull/19#discussion_r724139050) as I was not sure what types the governance contract expects. Leaving it to @cygnusv 