### PR TITLE
Add checkpoints to staking contract

### DIFF
--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -795,13 +795,12 @@ contract TokenStaking is Ownable, IStaking, Checkpoints {
         emit TokensSeized(operator, slashedAmount, true);
         if (undelegatedAt != 0) {
             operatorStruct.keepInTStake = 0;
-            decreaseStakeCheckpoint(operator, oldKeepInTStake);
-        } else {
-            decreaseStakeCheckpoint(
-                operator,
-                oldKeepInTStake - operatorStruct.keepInTStake
-            );
         }
+
+        decreaseStakeCheckpoint(
+            operator,
+            oldKeepInTStake - operatorStruct.keepInTStake
+        );
 
         authorizationDecrease(
             operator,
@@ -961,6 +960,13 @@ contract TokenStaking is Ownable, IStaking, Checkpoints {
         }
     }
 
+    /// @notice Delegate voting power from the stake associated to the
+    ///         `operator` to a `delegatee` address. Caller must be the owner
+    ///         of this stake.
+    function delegateVoting(address operator, address delegatee) external {
+        delegate(operator, delegatee);
+    }
+
     //
     //
     // Auxiliary functions
@@ -1049,13 +1055,6 @@ contract TokenStaking is Ownable, IStaking, Checkpoints {
     /// @notice Returns length of slashing queue
     function getSlashingQueueLength() external view override returns (uint256) {
         return slashingQueue.length;
-    }
-
-    /// @notice Delegate voting power from the stake associated to the
-    ///         `operator` to a `delegatee` address. Caller must be the owner
-    ///         of this stake.
-    function delegateVoting(address operator, address delegatee) public {
-        delegate(operator, delegatee);
     }
 
     /// @notice Requests decrease of the authorization for the given operator on

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -2,13 +2,15 @@
 
 pragma solidity 0.8.9;
 
+import "./IApplication.sol";
 import "./IStaking.sol";
 import "./ILegacyTokenStaking.sol";
 import "./IApplication.sol";
 import "./KeepStake.sol";
+import "../governance/Checkpoints.sol";
 import "../token/T.sol";
-import "../vending/VendingMachine.sol";
 import "../utils/PercentUtils.sol";
+import "../vending/VendingMachine.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
@@ -22,7 +24,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
 ///         that run on the Threshold Network. Note that legacy NU/KEEP staking
 ///         contracts see TokenStaking as an application (e.g., slashing is
 ///         requested by TokenStaking and performed by the legacy contracts).
-contract TokenStaking is Ownable, IStaking {
+contract TokenStaking is Ownable, IStaking, Checkpoints {
     using SafeERC20 for T;
     using PercentUtils for uint256;
     using SafeCast for uint256;

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -1403,6 +1403,48 @@ contract TokenStaking is Ownable, IStaking, Checkpoints {
         }
     }
 
+    /// @notice Creates new checkpoints due to an increment of a stakers' stake
+    /// @param _delegator Address of the stake owner acting as delegator
+    /// @param _amount Amount of T to increment
+    function increaseStakeCheckpoint(address _delegator, uint96 _amount)
+        internal
+    {
+        if (_amount == 0) {
+            return;
+        }
+        writeCheckpoint(_totalSupplyCheckpoints, add, _amount);
+        address delegatee = delegates(_delegator);
+        if (delegatee != address(0)) {
+            (uint256 oldWeight, uint256 newWeight) = writeCheckpoint(
+                _checkpoints[delegatee],
+                add,
+                _amount
+            );
+            emit DelegateVotesChanged(delegatee, oldWeight, newWeight);
+        }
+    }
+
+    /// @notice Creates new checkpoints due to a decrease of a stakers' stake
+    /// @param _delegator Address of the stake owner acting as delegator
+    /// @param _amount Amount of T to decrease
+    function decreaseStakeCheckpoint(address _delegator, uint96 _amount)
+        internal
+    {
+        if (_amount == 0) {
+            return;
+        }
+        writeCheckpoint(_totalSupplyCheckpoints, subtract, _amount);
+        address delegatee = delegates(_delegator);
+        if (delegatee != address(0)) {
+            (uint256 oldWeight, uint256 newWeight) = writeCheckpoint(
+                _checkpoints[delegatee],
+                subtract,
+                _amount
+            );
+            emit DelegateVotesChanged(delegatee, oldWeight, newWeight);
+        }
+    }
+
     /// @notice Returns amount of Nu stake in the NuCypher staking contract for the specified operator.
     ///         Resulting value in T denomination
     function getNuAmountInT(address owner, address operator)

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -8,7 +8,7 @@ module.exports = {
     settings: {
       optimizer: {
         enabled: true,
-        runs: 200,
+        runs: 10,
       },
     },
   },

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -2235,6 +2235,9 @@ describe("TokenStaking", () => {
           .connect(staker)
           .stake(operator.address, staker.address, staker.address, amount)
         blockTimestamp = await lastBlockTime()
+        await tokenStaking
+          .connect(staker)
+          .delegateVoting(operator.address, delegatee.address)
         await tToken.connect(deployer).transfer(operator.address, topUpAmount)
         await tToken
           .connect(operator)
@@ -2291,6 +2294,19 @@ describe("TokenStaking", () => {
         await expect(tx)
           .to.emit(tokenStaking, "ToppedUp")
           .withArgs(operator.address, topUpAmount)
+      })
+
+      it("should increase the delegatee voting power", async () => {
+        expect(await tokenStaking.getVotes(delegatee.address)).to.equal(
+          expectedAmount
+        )
+      })
+
+      it("should increase the total voting power", async () => {
+        const lastBlock = await mineBlock()
+        expect(await tokenStaking.getPastTotalSupply(lastBlock - 1)).to.equal(
+          expectedAmount
+        )
       })
     })
 
@@ -2356,6 +2372,9 @@ describe("TokenStaking", () => {
           true
         )
         await tokenStaking.stakeKeep(operator.address)
+        await tokenStaking
+          .connect(staker)
+          .delegateVoting(operator.address, delegatee.address)
         await tToken.connect(deployer).transfer(staker.address, topUpAmount)
         await tToken.connect(staker).approve(tokenStaking.address, topUpAmount)
         tx = await tokenStaking
@@ -2399,6 +2418,19 @@ describe("TokenStaking", () => {
           .to.emit(tokenStaking, "ToppedUp")
           .withArgs(operator.address, topUpAmount)
       })
+
+      it("should increase the delegatee voting power", async () => {
+        expect(await tokenStaking.getVotes(delegatee.address)).to.equal(
+          expectedAmount
+        )
+      })
+
+      it("should increase the total voting power", async () => {
+        const lastBlock = await mineBlock()
+        expect(await tokenStaking.getPastTotalSupply(lastBlock - 1)).to.equal(
+          expectedAmount
+        )
+      })
     })
 
     context("when operator has NuCypher stake", () => {
@@ -2413,6 +2445,9 @@ describe("TokenStaking", () => {
         await tokenStaking
           .connect(staker)
           .stakeNu(operator.address, staker.address, staker.address)
+        await tokenStaking
+          .connect(staker)
+          .delegateVoting(operator.address, delegatee.address)
         await tToken.connect(deployer).transfer(operator.address, topUpAmount)
         await tToken
           .connect(operator)
@@ -2457,6 +2492,19 @@ describe("TokenStaking", () => {
         await expect(tx)
           .to.emit(tokenStaking, "ToppedUp")
           .withArgs(operator.address, topUpAmount)
+      })
+
+      it("should increase the delegatee voting power", async () => {
+        expect(await tokenStaking.getVotes(delegatee.address)).to.equal(
+          expectedAmount
+        )
+      })
+
+      it("should increase the total voting power", async () => {
+        const lastBlock = await mineBlock()
+        expect(await tokenStaking.getPastTotalSupply(lastBlock - 1)).to.equal(
+          expectedAmount
+        )
       })
     })
   })
@@ -2589,6 +2637,9 @@ describe("TokenStaking", () => {
           true
         )
         await tokenStaking.stakeKeep(operator.address)
+        await tokenStaking
+          .connect(staker)
+          .delegateVoting(operator.address, delegatee.address)
         await keepStakingMock.setAmount(operator.address, newKeepAmount)
         tx = await tokenStaking.connect(operator).topUpKeep(operator.address)
       })
@@ -2637,6 +2688,19 @@ describe("TokenStaking", () => {
             operator.address,
             newKeepInTAmount.sub(initialKeepInTAmount)
           )
+      })
+
+      it("should increase the delegatee voting power", async () => {
+        expect(await tokenStaking.getVotes(delegatee.address)).to.equal(
+          newKeepInTAmount
+        )
+      })
+
+      it("should increase the total voting power", async () => {
+        const lastBlock = await mineBlock()
+        expect(await tokenStaking.getPastTotalSupply(lastBlock - 1)).to.equal(
+          newKeepInTAmount
+        )
       })
     })
 
@@ -2883,6 +2947,9 @@ describe("TokenStaking", () => {
         await tokenStaking
           .connect(staker)
           .stakeNu(operator.address, staker.address, staker.address)
+        await tokenStaking
+          .connect(staker)
+          .delegateVoting(operator.address, delegatee.address)
         await nucypherStakingMock.setStaker(staker.address, newNuAmount)
         tx = await tokenStaking.connect(staker).topUpNu(operator.address)
       })
@@ -2931,6 +2998,19 @@ describe("TokenStaking", () => {
         await expect(tx)
           .to.emit(tokenStaking, "ToppedUp")
           .withArgs(operator.address, newNuInTAmount.sub(initialNuInTAmount))
+      })
+
+      it("should increase the delegatee voting power", async () => {
+        expect(await tokenStaking.getVotes(delegatee.address)).to.equal(
+          newNuInTAmount
+        )
+      })
+
+      it("should increase the total voting power", async () => {
+        const lastBlock = await mineBlock()
+        expect(await tokenStaking.getPastTotalSupply(lastBlock - 1)).to.equal(
+          newNuInTAmount
+        )
       })
     })
 
@@ -3393,7 +3473,9 @@ describe("TokenStaking", () => {
         await tokenStaking
           .connect(staker)
           .stakeNu(operator.address, beneficiary.address, authorizer.address)
-
+        await tokenStaking
+          .connect(staker)
+          .delegateVoting(operator.address, delegatee.address)
         await tToken.connect(staker).approve(tokenStaking.address, amount)
         await tokenStaking.connect(staker).topUp(operator.address, amount)
 
@@ -3416,6 +3498,19 @@ describe("TokenStaking", () => {
         expect(
           await tokenStaking.getStartTStakingTimestamp(operator.address)
         ).to.equal(0)
+      })
+
+      it("should decrease the delegatee voting power", async () => {
+        expect(await tokenStaking.getVotes(delegatee.address)).to.equal(
+          nuInTAmount
+        )
+      })
+
+      it("should decrease the total voting power", async () => {
+        const lastBlock = await mineBlock()
+        expect(await tokenStaking.getPastTotalSupply(lastBlock - 1)).to.equal(
+          nuInTAmount
+        )
       })
 
       it("should transfer tokens to the staker address", async () => {
@@ -3557,6 +3652,9 @@ describe("TokenStaking", () => {
           true
         )
         await tokenStaking.stakeKeep(operator.address)
+        await tokenStaking
+          .connect(staker)
+          .delegateVoting(operator.address, delegatee.address)
 
         await tToken.connect(staker).approve(tokenStaking.address, tAmount)
         await tokenStaking.connect(staker).topUp(operator.address, tAmount)
@@ -3613,6 +3711,17 @@ describe("TokenStaking", () => {
         await expect(tx)
           .to.emit(tokenStaking, "Unstaked")
           .withArgs(operator.address, keepInTAmount)
+      })
+
+      it("should decrease the delegatee voting power", async () => {
+        expect(await tokenStaking.getVotes(delegatee.address)).to.equal(tAmount)
+      })
+
+      it("should decrease the total voting power", async () => {
+        const lastBlock = await mineBlock()
+        expect(await tokenStaking.getPastTotalSupply(lastBlock - 1)).to.equal(
+          tAmount
+        )
       })
     })
   })
@@ -3747,7 +3856,9 @@ describe("TokenStaking", () => {
         await tokenStaking
           .connect(staker)
           .stakeNu(operator.address, beneficiary.address, authorizer.address)
-
+        await tokenStaking
+          .connect(staker)
+          .delegateVoting(operator.address, delegatee.address)
         await tToken.connect(staker).approve(tokenStaking.address, tAmount)
         await tokenStaking.connect(staker).topUp(operator.address, tAmount)
 
@@ -3764,7 +3875,7 @@ describe("TokenStaking", () => {
           .unstakeNu(operator.address, amountToUnstake)
       })
 
-      it("should ypdate Nu staked amount", async () => {
+      it("should update Nu staked amount", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           beneficiary.address,
@@ -3808,6 +3919,19 @@ describe("TokenStaking", () => {
         await expect(tx)
           .to.emit(tokenStaking, "Unstaked")
           .withArgs(operator.address, expectedUnstaked)
+      })
+
+      it("should decrease the delegatee voting power", async () => {
+        expect(await tokenStaking.getVotes(delegatee.address)).to.equal(
+          expectedNuInTAmount.add(tAmount)
+        )
+      })
+
+      it("should decrease the total voting power", async () => {
+        const lastBlock = await mineBlock()
+        expect(await tokenStaking.getPastTotalSupply(lastBlock - 1)).to.equal(
+          expectedNuInTAmount.add(tAmount)
+        )
       })
     })
 
@@ -5854,6 +5978,9 @@ describe("TokenStaking", () => {
           .stake(operator.address, staker.address, staker.address, tAmount)
         await tokenStaking
           .connect(staker)
+          .delegateVoting(operator.address, delegatee.address)
+        await tokenStaking
+          .connect(staker)
           .increaseAuthorization(
             operator.address,
             application1Mock.address,
@@ -5934,6 +6061,12 @@ describe("TokenStaking", () => {
             zeroBigNumber,
             zeroBigNumber,
           ])
+        })
+
+        it("should decrease the delegatee voting power", async () => {
+          expect(await tokenStaking.getVotes(delegatee.address)).to.equal(
+            expectedAmount
+          )
         })
 
         it("should update index of queue", async () => {

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -669,7 +669,7 @@ describe("TokenStaking", () => {
       it("should revert", async () => {
         await expect(
           tokenStaking.connect(operator).refreshKeepStakeOwner(operator.address)
-        ).to.be.revertedWith("Not old owner")
+        ).to.be.revertedWith("Caller is not owner")
       })
     })
 
@@ -690,7 +690,7 @@ describe("TokenStaking", () => {
           tokenStaking
             .connect(authorizer)
             .refreshKeepStakeOwner(operator.address)
-        ).to.be.revertedWith("Not old owner")
+        ).to.be.revertedWith("Caller is not owner")
       })
     })
 


### PR DESCRIPTION
Adds checkpoints to staking contract, so that stakers can collect and delegate voting power in proportion to their stake size.
Some important aspects to note:
* Delegation of stake voting power is controlled by the owner (i.e., the owner decides to whom delegate their vote)
* Threshold model of staking roles allows for different stakes, associated to different operators, but with the same stake owner. Conversely, this means that the same owner address can have multiple stakes associated to different operators. In practice, in this situation the owner must delegate each stake individually.
* Because of the particularities of the Threshold model of staking roles, the delegation function requires an extra parameter, that is, the operator address, in order to uniquely identify each stake:
```js
    /// @notice Delegate voting power from the stake associated to the
    ///         `operator` to a `delegatee` address. Caller must be the owner
    ///         of this stake.
    function delegateVoting(address operator, address delegatee) public {
        delegate(operator, delegatee);
    }
```