### PR TITLE
Hardcode grant stake owners in KeepStake library

### DIFF
--- a/contracts/staking/ILegacyTokenStaking.sol
+++ b/contracts/staking/ILegacyTokenStaking.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity 0.8.4;
+
+/// @title IKeepTokenStaking
+/// @notice Interface for Keep TokenStaking contract
+interface IKeepTokenStaking {
+    /// @notice Seize provided token amount from every member in the misbehaved
+    /// operators array. The tattletale is rewarded with 5% of the total seized
+    /// amount scaled by the reward adjustment parameter and the rest 95% is burned.
+    /// @param amountToSeize Token amount to seize from every misbehaved operator.
+    /// @param rewardMultiplier Reward adjustment in percentage. Min 1% and 100% max.
+    /// @param tattletale Address to receive the 5% reward.
+    /// @param misbehavedOperators Array of addresses to seize the tokens from.
+    function seize(
+        uint256 amountToSeize,
+        uint256 rewardMultiplier,
+        address tattletale,
+        address[] memory misbehavedOperators
+    ) external;
+
+    /// @notice Gets stake delegation info for the given operator.
+    /// @param _operator Operator address.
+    /// @return amount The amount of tokens the given operator delegated.
+    /// @return createdAt The time when the stake has been delegated.
+    /// @return undelegatedAt The time when undelegation has been requested.
+    /// If undelegation has not been requested, 0 is returned.
+    function getDelegationInfo(address _operator)
+        external
+        view
+        returns (
+            uint256 amount,
+            uint256 createdAt,
+            uint256 undelegatedAt
+        );
+
+    /// @notice Gets the stake owner for the specified operator address.
+    /// @return Stake owner address.
+    function ownerOf(address _operator) external view returns (address);
+
+    /// @notice Gets the beneficiary for the specified operator address.
+    /// @return Beneficiary address.
+    function beneficiaryOf(address _operator)
+        external
+        view
+        returns (address payable);
+
+    /// @notice Gets the authorizer for the specified operator address.
+    /// @return Authorizer address.
+    function authorizerOf(address _operator) external view returns (address);
+
+    /// @notice Gets the eligible stake balance of the specified address.
+    /// An eligible stake is a stake that passed the initialization period
+    /// and is not currently undelegating. Also, the operator had to approve
+    /// the specified operator contract.
+    ///
+    /// Operator with a minimum required amount of eligible stake can join the
+    /// network and participate in new work selection.
+    ///
+    /// @param _operator address of stake operator.
+    /// @param _operatorContract address of operator contract.
+    /// @return balance an uint256 representing the eligible stake balance.
+    function eligibleStake(address _operator, address _operatorContract)
+        external
+        view
+        returns (uint256 balance);
+}
+
+/// @title INuCypherStakingEscrow
+/// @notice Interface for NuCypher StakingEscrow contract
+interface INuCypherStakingEscrow {
+    /// @notice Slash the staker's stake and reward the investigator
+    /// @param _staker Staker's address
+    /// @param _penalty Penalty
+    /// @param _investigator Investigator
+    /// @param _reward Reward for the investigator
+    function slashStaker(
+        address _staker,
+        uint256 _penalty,
+        address _investigator,
+        uint256 _reward
+    ) external;
+
+    /// @notice Request merge between NuCypher staking contract and T staking contract.
+    ///         Returns amount of staked tokens
+    function requestMerge(address staker, address operator)
+        external
+        returns (uint256);
+
+    /// @notice Get all tokens belonging to the staker
+    function getAllTokens(address _staker) external view returns (uint256);
+}
+
+/// @title IKeepTokenGrant
+/// @notice Interface for Keep TokenGrant contract
+interface IKeepTokenGrant {
+    /// @notice Gets grant by ID. Returns only basic grant data.
+    /// @param _id ID of the token grant.
+    /// @return amount The amount of tokens the grant provides.
+    /// @return withdrawn The amount of tokens that have already been withdrawn
+    ///                   from the grant.
+    /// @return staked The amount of tokens that have been staked from the grant.
+    /// @return revokedAmount The number of tokens revoked from the grantee.
+    /// @return revokedAt Timestamp at which grant was revoked by the grant manager.
+    /// @return grantee The grantee of grant.
+    function getGrant(uint256 _id)
+        external
+        view
+        returns (
+            uint256 amount,
+            uint256 withdrawn,
+            uint256 staked,
+            uint256 revokedAmount,
+            uint256 revokedAt,
+            address grantee
+        );
+
+    /// @notice Gets grant stake details of the given operator.
+    /// @param operator The operator address.
+    /// @return grantId ID of the token grant.
+    /// @return amount The amount of tokens the given operator delegated.
+    /// @return stakingContract The address of staking contract.
+    function getGrantStakeDetails(address operator)
+        external
+        view
+        returns (
+            uint256 grantId,
+            uint256 amount,
+            address stakingContract
+        );
+}
+
+/// @title IKeepManagedGrant
+/// @notice Interface for Keep ManagedGrant contract
+interface IKeepManagedGrant {
+    /// @notice Returns address of grantee
+    function grantee() external view returns (address);
+}

--- a/contracts/staking/KeepStake.sol
+++ b/contracts/staking/KeepStake.sol
@@ -1,0 +1,297 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity 0.8.4;
+
+import "./ILegacyTokenStaking.sol";
+
+interface IManagedGrant {
+    function grantee() external view returns (address);
+}
+
+contract KeepStake {
+    function resolveOwner(IKeepTokenStaking tokenStaking, address operator)
+        external
+        view
+        returns (address)
+    {
+        if (operator == 0x855A951162B1B93D70724484d5bdc9D00B56236B) {
+            return
+                IManagedGrant(0xFADbF758307A054C57B365Db1De90acA71feaFE5)
+                    .grantee();
+        }
+        if (operator == 0xF1De9490Bf7298b5F350cE74332Ad7cf8d5cB181) {
+            return
+                IManagedGrant(0xAEd493Aaf3E76E83b29E151848b71eF4544f92f1)
+                    .grantee();
+        }
+        if (operator == 0x39d2aCBCD80d80080541C6eed7e9feBb8127B2Ab) {
+            return
+                IManagedGrant(0xA2fa09D6f8C251422F5fde29a0BAd1C53dEfAe66)
+                    .grantee();
+        }
+        if (operator == 0xd66cAE89FfBc6E50e6b019e45c1aEc93Dec54781) {
+            return
+                IManagedGrant(0x306309f9d105F34132db0bFB3Ce3f5B0245Cd386)
+                    .grantee();
+        }
+        if (operator == 0x2eBE08379f4fD866E871A9b9E1d5C695154C6A9F) {
+            return
+                IManagedGrant(0xd00c0d43b747C33726B3f0ff4BDA4b72dc53c6E9)
+                    .grantee();
+        }
+        if (operator == 0xA97c34278162b556A527CFc01B53eb4DDeDFD223) {
+            return
+                IManagedGrant(0xB3E967355c456B1Bd43cB0188A321592D410D096)
+                    .grantee();
+        }
+        if (operator == 0x6C76d49322C9f8761A1623CEd89A31490cdB649d) {
+            return
+                IManagedGrant(0xB3E967355c456B1Bd43cB0188A321592D410D096)
+                    .grantee();
+        }
+        if (operator == 0x4a41c7a884d119eaaefE471D0B3a638226408382) {
+            return
+                IManagedGrant(0xcdf3d216d82a463Ce82971F2F5DA3d8f9C5f093A)
+                    .grantee();
+        }
+        if (operator == 0x9c06Feb7Ebc8065ee11Cd5E8EEdaAFb2909A7087) {
+            return
+                IManagedGrant(0x45119cd98d145283762BA9eBCAea75F72D188733)
+                    .grantee();
+        }
+        if (operator == 0x9bD818Ab6ACC974f2Cf2BD2EBA7a250126Accb9F) {
+            return
+                IManagedGrant(0x6E535043377067621954ee84065b0bd7357e7aBa)
+                    .grantee();
+        }
+        if (operator == 0x1d803c89760F8B4057DB15BCb3B8929E0498D310) {
+            return
+                IManagedGrant(0xB3E967355c456B1Bd43cB0188A321592D410D096)
+                    .grantee();
+        }
+        if (operator == 0x3101927DEeC27A2bfA6c4a6316e3A221f631dB91) {
+            return
+                IManagedGrant(0x178Bf1946feD0e2362fdF8bcD3f91F0701a012C6)
+                    .grantee();
+        }
+        if (operator == 0x9d9b187E478bC62694A7bED216Fc365de87F280C) {
+            return
+                IManagedGrant(0xFBad17CFad6cb00D726c65501D69FdC13Ca5477c)
+                    .grantee();
+        }
+        if (operator == 0xd977144724Bc77FaeFAe219F958AE3947205d0b5) {
+            return
+                IManagedGrant(0x087B442BFd4E42675cf2df5fa566F87d7A96Fb12)
+                    .grantee();
+        }
+        if (operator == 0x045E511f53DeBF55c9C0B4522f14F602f7C7cA81) {
+            return
+                IManagedGrant(0xFcfe8C036C414a15cF871071c483687095caF7D6)
+                    .grantee();
+        }
+        if (operator == 0x3Dd301b3c96A282d8092E1e6f6846f24172D45C1) {
+            return
+                IManagedGrant(0xb5Bdd2D9B3541fc8f581Af37430D26527e59aeF8)
+                    .grantee();
+        }
+        if (operator == 0x5d84DEB482E770479154028788Df79aA7C563aA4) {
+            return
+                IManagedGrant(0x9D1a179c469a8BdD0b683A9f9250246cc47e8fBE)
+                    .grantee();
+        }
+        if (operator == 0x1dF927B69A97E8140315536163C029d188e8573b) {
+            return
+                IManagedGrant(0xb5Bdd2D9B3541fc8f581Af37430D26527e59aeF8)
+                    .grantee();
+        }
+        if (operator == 0x617daCE069Fbd41993491de211b4DfccdAcbd348) {
+            return
+                IManagedGrant(0xb5Bdd2D9B3541fc8f581Af37430D26527e59aeF8)
+                    .grantee();
+        }
+        if (operator == 0x650A9eD18Df873cad98C88dcaC8170531cAD2399) {
+            return
+                IManagedGrant(0x1Df7324A3aD20526DFa02Cc803eD2D97Cac81F3b)
+                    .grantee();
+        }
+        if (operator == 0x07C9a8f8264221906b7b8958951Ce4753D39628B) {
+            return
+                IManagedGrant(0x305D12b4d70529Cd618dA7399F5520701E510041)
+                    .grantee();
+        }
+        if (operator == 0x63eB4c3DD0751F9BE7070A01156513C227fa1eF6) {
+            return
+                IManagedGrant(0x306309f9d105F34132db0bFB3Ce3f5B0245Cd386)
+                    .grantee();
+        }
+        if (operator == 0xc6349eEC31048787676b6297ba71721376A8DdcF) {
+            return
+                IManagedGrant(0xac1a985E75C6a0b475b9c807Ad0705a988Be2D99)
+                    .grantee();
+        }
+        if (operator == 0x3B945f9C0C8737e44f8e887d4F04B5B3A491Ac4d) {
+            return
+                IManagedGrant(0x82e17477726E8D9D2C237745cA9989631582eE98)
+                    .grantee();
+        }
+        if (operator == 0xF35343299a4f80Dd5D917bbe5ddd54eBB820eBd4) {
+            return
+                IManagedGrant(0xCC88c15506251B62ccCeebA193e100d6bBC9a30D)
+                    .grantee();
+        }
+        if (operator == 0x3B9e5ae72d068448bB96786989c0d86FBC0551D1) {
+            return
+                IManagedGrant(0x306309f9d105F34132db0bFB3Ce3f5B0245Cd386)
+                    .grantee();
+        }
+        if (operator == 0xB2D53Be158Cb8451dFc818bD969877038c1BdeA1) {
+            return
+                IManagedGrant(0xaE55e3800f0A3feaFdcE535A8C0fab0fFdB90DEe)
+                    .grantee();
+        }
+        if (operator == 0xF6dbF7AFe05b8Bb6f198eC7e69333c98D3C4608C) {
+            return
+                IManagedGrant(0xbb8D24a20c20625f86739824014C3cBAAAb26700)
+                    .grantee();
+        }
+        if (operator == 0xB62Fc1ADfFb2ab832041528C8178358338d85f76) {
+            return
+                IManagedGrant(0x9ED98fD1C29018B9342CB8F57A3073B9695f0c02)
+                    .grantee();
+        }
+        if (operator == 0x9bC8d30d971C9e74298112803036C05db07D73e3) {
+            return
+                IManagedGrant(0x66beda757939f8e505b5Eb883cd02C8d4a11Bca2)
+                    .grantee();
+        }
+
+        if (operator == 0x1147ccFB4AEFc6e587a23b78724Ef20Ec6e474D4) {
+            return 0x3FB49dA4375Ef9019f17990D04c6d5daD482D80a;
+        }
+        if (operator == 0x4c21541f95a00C03C75F38C71DC220bd27cbbEd9) {
+            return 0xC897cfeE43a8d827F76D4226994D5CE5EBBe2571;
+        }
+        if (operator == 0x855A951162B1B93D70724484d5bdc9D00B56236B) {
+            return 0xFADbF758307A054C57B365Db1De90acA71feaFE5;
+        }
+        if (operator == 0xF1De9490Bf7298b5F350cE74332Ad7cf8d5cB181) {
+            return 0xAEd493Aaf3E76E83b29E151848b71eF4544f92f1;
+        }
+        if (operator == 0x7E6332d18719a5463d3867a1a892359509589a3d) {
+            return 0x1578eD833D986c1188D1a998aA5FEcD418beF5da;
+        }
+        if (operator == 0x39d2aCBCD80d80080541C6eed7e9feBb8127B2Ab) {
+            return 0xA2fa09D6f8C251422F5fde29a0BAd1C53dEfAe66;
+        }
+        if (operator == 0x8Bd660A764Ca14155F3411a4526a028b6316CB3E) {
+            return 0xf6f372DfAeCC1431186598c304e91B79Ce115766;
+        }
+        if (operator == 0xd66cAE89FfBc6E50e6b019e45c1aEc93Dec54781) {
+            return 0x306309f9d105F34132db0bFB3Ce3f5B0245Cd386;
+        }
+        if (operator == 0x2eBE08379f4fD866E871A9b9E1d5C695154C6A9F) {
+            return 0xd00c0d43b747C33726B3f0ff4BDA4b72dc53c6E9;
+        }
+        if (operator == 0xA97c34278162b556A527CFc01B53eb4DDeDFD223) {
+            return 0xB3E967355c456B1Bd43cB0188A321592D410D096;
+        }
+        if (operator == 0x6C76d49322C9f8761A1623CEd89A31490cdB649d) {
+            return 0xB3E967355c456B1Bd43cB0188A321592D410D096;
+        }
+        if (operator == 0x4a41c7a884d119eaaefE471D0B3a638226408382) {
+            return 0xcdf3d216d82a463Ce82971F2F5DA3d8f9C5f093A;
+        }
+        if (operator == 0x9c06Feb7Ebc8065ee11Cd5E8EEdaAFb2909A7087) {
+            return 0x45119cd98d145283762BA9eBCAea75F72D188733;
+        }
+        if (operator == 0x9bD818Ab6ACC974f2Cf2BD2EBA7a250126Accb9F) {
+            return 0x6E535043377067621954ee84065b0bd7357e7aBa;
+        }
+        if (operator == 0x1d803c89760F8B4057DB15BCb3B8929E0498D310) {
+            return 0xB3E967355c456B1Bd43cB0188A321592D410D096;
+        }
+        if (operator == 0x3101927DEeC27A2bfA6c4a6316e3A221f631dB91) {
+            return 0x178Bf1946feD0e2362fdF8bcD3f91F0701a012C6;
+        }
+        if (operator == 0x9d9b187E478bC62694A7bED216Fc365de87F280C) {
+            return 0xFBad17CFad6cb00D726c65501D69FdC13Ca5477c;
+        }
+        if (operator == 0xd977144724Bc77FaeFAe219F958AE3947205d0b5) {
+            return 0x087B442BFd4E42675cf2df5fa566F87d7A96Fb12;
+        }
+        if (operator == 0x045E511f53DeBF55c9C0B4522f14F602f7C7cA81) {
+            return 0xFcfe8C036C414a15cF871071c483687095caF7D6;
+        }
+        if (operator == 0x3Dd301b3c96A282d8092E1e6f6846f24172D45C1) {
+            return 0xb5Bdd2D9B3541fc8f581Af37430D26527e59aeF8;
+        }
+        if (operator == 0x5d84DEB482E770479154028788Df79aA7C563aA4) {
+            return 0x9D1a179c469a8BdD0b683A9f9250246cc47e8fBE;
+        }
+        if (operator == 0x1dF927B69A97E8140315536163C029d188e8573b) {
+            return 0xb5Bdd2D9B3541fc8f581Af37430D26527e59aeF8;
+        }
+        if (operator == 0x617daCE069Fbd41993491de211b4DfccdAcbd348) {
+            return 0xb5Bdd2D9B3541fc8f581Af37430D26527e59aeF8;
+        }
+        if (operator == 0x650A9eD18Df873cad98C88dcaC8170531cAD2399) {
+            return 0x1Df7324A3aD20526DFa02Cc803eD2D97Cac81F3b;
+        }
+        if (operator == 0x07C9a8f8264221906b7b8958951Ce4753D39628B) {
+            return 0x305D12b4d70529Cd618dA7399F5520701E510041;
+        }
+        if (operator == 0x4F4f0D0dfd93513B3f4Cb116Fe9d0A005466F725) {
+            return 0x8b055ac1c4dd287E2a46D4a52d61FE76FB551bD0;
+        }
+        if (operator == 0x1DF0250027fEC876d8876d1ac7A392c9098F1a1e) {
+            return 0xE408fFa969707Ce5d7aA3e5F8d44674Fa4b26219;
+        }
+        if (operator == 0x63eB4c3DD0751F9BE7070A01156513C227fa1eF6) {
+            return 0x306309f9d105F34132db0bFB3Ce3f5B0245Cd386;
+        }
+        if (operator == 0xc6349eEC31048787676b6297ba71721376A8DdcF) {
+            return 0xac1a985E75C6a0b475b9c807Ad0705a988Be2D99;
+        }
+        if (operator == 0x3B945f9C0C8737e44f8e887d4F04B5B3A491Ac4d) {
+            return 0x82e17477726E8D9D2C237745cA9989631582eE98;
+        }
+        if (operator == 0xF35343299a4f80Dd5D917bbe5ddd54eBB820eBd4) {
+            return 0xCC88c15506251B62ccCeebA193e100d6bBC9a30D;
+        }
+        if (operator == 0x860EF3f83B6adFEF757F98345c3B8DdcFCA9d152) {
+            return 0x08a3633AAb8f3E436DEA204288Ee26Fe094406b0;
+        }
+        if (operator == 0xe3a2d16dA142E6B190A5d9F7e0C07cc460B58A5F) {
+            return 0x875f8fFCDDeD63B5d8Cf54be4E4b82FE6c6E249C;
+        }
+        if (operator == 0xBDE07f1cA107Ef319b0Bb26eBF1d0a5b4c97ffc1) {
+            return 0x1578eD833D986c1188D1a998aA5FEcD418beF5da;
+        }
+        if (operator == 0xE86181D6b672d78D33e83029fF3D0ef4A601B4C4) {
+            return 0x1578eD833D986c1188D1a998aA5FEcD418beF5da;
+        }
+        if (operator == 0x3B9e5ae72d068448bB96786989c0d86FBC0551D1) {
+            return 0x306309f9d105F34132db0bFB3Ce3f5B0245Cd386;
+        }
+        if (operator == 0xB2D53Be158Cb8451dFc818bD969877038c1BdeA1) {
+            return 0xaE55e3800f0A3feaFdcE535A8C0fab0fFdB90DEe;
+        }
+        if (operator == 0xb7c561e2069aCaE2c4480111B1606790BB4E13fE) {
+            return 0x1578eD833D986c1188D1a998aA5FEcD418beF5da;
+        }
+        if (operator == 0x526c013f8382B050d32d86e7090Ac84De22EdA4D) {
+            return 0x61C6E5DDacded540CD08066C08cbc096d22D91f4;
+        }
+        if (operator == 0xF6dbF7AFe05b8Bb6f198eC7e69333c98D3C4608C) {
+            return 0xbb8D24a20c20625f86739824014C3cBAAAb26700;
+        }
+        if (operator == 0xB62Fc1ADfFb2ab832041528C8178358338d85f76) {
+            return 0x9ED98fD1C29018B9342CB8F57A3073B9695f0c02;
+        }
+        if (operator == 0x9bC8d30d971C9e74298112803036C05db07D73e3) {
+            return 0x66beda757939f8e505b5Eb883cd02C8d4a11Bca2;
+        }
+
+        return tokenStaking.ownerOf(operator);
+    }
+}


### PR DESCRIPTION
See https://github.com/keep-network/keep-core/pull/2697
See https://github.com/threshold-network/solidity-contracts/pull/7

T staking contract supports existing KEEP stakes by allowing KEEP stakers
to use their stakes in T network and weights them based on KEEP<>T token
ratio. KEEP stake owner is cached in T staking contract and used to restrict
access to all `onlyOwnerOrOperator` functions. To cache KEEP staking contract
in T staking contract, we first need to resolve the owner. Resolving liquid
KEEP stake owner is easy - `TokenStaking.ownerOf` gives the answer immediately.
Resolving token grant stake owner is complicated and not possible to do on-chain
from an external contract. Keep `TokenStaking` knows the grant ID but does
not expose it externally. Going through `TokenGrant` may not always give the
right answer. Finally, we never know on-chain if we are dealing with
a `ManagedGrant` or not. Porting all this complexity to T staking contract does
not feel like the right choice.

It's time to make a tradeoff.

To solve this problem, we resolve all owners off-chain based on events and
hardcode them in `KeepStake` library. Worth noting, owner of a grant delegation
can never change in Keep `TokenStaking` contract and this is why hardcoding
should be acceptable.

Operator-owner pairs were snapshotted 2021-11-10 in the following way:

1. Take all Keep `TokenStaking` delegations ever.
2. Filter out undelegated operators.
3. Filter out canceled delegations.
4. Fetch grant stake information from `TokenGrant` for that operator
   to determine if we are dealing with grant delegation.
5. Fetch grantee address from Keep `TokenGrant` contract.
6. Check if we are dealing with `ManagedGrant` by looking for all created
   `ManagedGrants` and comparing their address against grantee address
   fetched from `TokenGrant` contract.

One important implication of this decision is that new grant owners
staking from a grant and not included in the snapshot WILL NOT HAVE
their Keep stake supported in T which I think is a good trade-off.
We will support all existing Keep stakes so current operators lose
nothing while new operators must first wrap into T and then stake into
T directly.