### PR TITLE
Remove testing configuration in npm.yml

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -39,7 +39,7 @@ jobs:
           branch: ${{ github.ref }}
           commit: ${{ github.sha }}
 
-      - name: Publish package # TODO: switch off --dry-run
+      - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=hardhat --tag=development --dry-run
+        run: npm publish --access=public --network=hardhat --tag=development


### PR DESCRIPTION
Before the change, the `--dry-run` flag was used in the `npm publish`
step to verify the workflow without actually posting an NPM package to
the registry. Now that we have the workflow verified, we can remove the
testing configuration.

Link to the run of the workflow with the `--dry-run`:
https://github.com/threshold-network/solidity-contracts/actions/runs/1525705757