### PR TITLE
Use `-dev` suffix in the versioning of the `solidity-contracts` module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threshold-network/solidity-contracts",
-  "version": "0.0.1",
+  "version": "0.0.2-dev",
   "license": "GPL-3.0-or-later",
   "files": [
     "artifacts/",


### PR DESCRIPTION
`-dev` suffix will be used for the versioning of the `solidity-contracts`
module built with the purpose of being used on development environment.
Packages with the `-dev`-suffix will be pushed to the NPM registry by
the `NPM` GH Actions workflow.
Note that packages ment for the test environment (Ropsten) will be
versioned independently, based on the suffix provided during manual
triggering of the `Main` workflow in `ci` project.