### PR TITLE
Tag testnet deployment

### DIFF
--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -146,7 +146,7 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=${{ github.event.inputs.environment }}
+        run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }}
 
       - name: Upload files needed for etherscan verification
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
When building and publishing token dashboard on testnet we need to use
dependency to the latest `threshold-network/solidity-contracts` package
containing contracts deployed on that testnet. In order to do that
easily, we should use a tag for all such `solidity-contracts` packages.
Here we're adding the tagging. NPM publish step is executed only for
`workflow_dispatch` event, that means that we can use `environment`
input for tagging the package.