### PR TITLE
Adds time restriction to unstaking NU

### DIFF
--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -317,11 +317,11 @@ interface IStaking {
             uint96 nuInTStake
         );
 
-    /// @notice Returns start staking timestamp for T stake.
+    /// @notice Returns start staking timestamp for T/NU stake.
     /// @dev    This value is set at most once, and only when a stake is created
-    ///         with T tokens. If a stake is created from a legacy stake,
-    ///         this value will remain as zero
-    function getStartTStakingTimestamp(address operator)
+    ///         with T or NU tokens. If a stake is created from a legacy KEEP
+    ///         stake, this value will remain as zero
+    function getStartStakingTimestamp(address operator)
         external
         view
         returns (uint256);

--- a/docs/rfc-1-staking-contract.adoc
+++ b/docs/rfc-1-staking-contract.adoc
@@ -506,11 +506,11 @@ Returns the authorized stake amount of the operator for the application.
 Returns staked amount of T, Keep and Nu for the specified operator. All values
 are in T denomination.
 
-==== `getStartTStakingTimestamp(address operator) external view returns (uint256)`
+==== `getStartStakingTimestamp(address operator) external view returns (uint256)`
 
-Returns start staking timestamp for T stake. This value is set at most once, 
-and only when a stake is created with T tokens. If a stake is created from 
-a legacy stake, this value will remain as zero.
+Returns start staking timestamp for T/NU stake. This value is set at most once, 
+and only when a stake is created with T or NU tokens. If a stake is created 
+from a legacy KEEP stake, this value will remain as zero.
 
 ==== `stakedNu(address operator) external view returns (uint256)`
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -18,7 +18,7 @@ const config: HardhatUserConfig = {
         settings: {
           optimizer: {
             enabled: true,
-            runs: 100,
+            runs: 10,
           },
         },
       },

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -346,9 +346,9 @@ describe("TokenStaking", () => {
         expect(await tokenStaking.stakedNu(operator.address)).to.equal(0)
       })
 
-      it("should start T staking timestamp", async () => {
+      it("should start staking timestamp", async () => {
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(blockTimestamp)
       })
 
@@ -517,9 +517,9 @@ describe("TokenStaking", () => {
           expect(await tokenStaking.stakedNu(operator.address)).to.equal(0)
         })
 
-        it("should not start T staking timestamp", async () => {
+        it("should not start staking timestamp", async () => {
           expect(
-            await tokenStaking.getStartTStakingTimestamp(operator.address)
+            await tokenStaking.getStartStakingTimestamp(operator.address)
           ).to.equal(0)
         })
 
@@ -695,6 +695,7 @@ describe("TokenStaking", () => {
       const conversion = convertToT(nuAmount, nuRatio)
       const tAmount = conversion.result
       let tx
+      let blockTimestamp
 
       beforeEach(async () => {
         await nucypherStakingMock.setStaker(staker.address, nuAmount)
@@ -702,6 +703,7 @@ describe("TokenStaking", () => {
         tx = await tokenStaking
           .connect(staker)
           .stakeNu(operator.address, beneficiary.address, authorizer.address)
+        blockTimestamp = await lastBlockTime()
       })
 
       it("should set roles equal to the provided values", async () => {
@@ -723,10 +725,10 @@ describe("TokenStaking", () => {
         )
       })
 
-      it("should not start T staking timestamp", async () => {
+      it("should start staking timestamp", async () => {
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
-        ).to.equal(0)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
+        ).to.equal(blockTimestamp)
       })
 
       it("should do callback to NuCypher staking contract", async () => {
@@ -2604,14 +2606,14 @@ describe("TokenStaking", () => {
         ])
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           staker.address,
           staker.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(blockTimestamp)
       })
 
@@ -2686,7 +2688,7 @@ describe("TokenStaking", () => {
           Zero,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(blockTimestamp)
       })
 
@@ -2742,14 +2744,14 @@ describe("TokenStaking", () => {
         ])
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           beneficiary.address,
           authorizer.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(0)
       })
 
@@ -2794,12 +2796,14 @@ describe("TokenStaking", () => {
       const topUpAmount = initialStakerBalance.mul(2)
       const expectedAmount = nuInTAmount.add(topUpAmount)
       let tx
+      let blockTimestamp
 
       beforeEach(async () => {
         await nucypherStakingMock.setStaker(staker.address, nuAmount)
         await tokenStaking
           .connect(staker)
           .stakeNu(operator.address, staker.address, staker.address)
+        blockTimestamp = await lastBlockTime()
         await tokenStaking
           .connect(staker)
           .delegateVoting(operator.address, delegatee.address)
@@ -2820,15 +2824,15 @@ describe("TokenStaking", () => {
         ])
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           staker.address,
           staker.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
-        ).to.equal(0)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
+        ).to.equal(blockTimestamp)
       })
 
       it("should increase available amount to authorize", async () => {
@@ -3010,14 +3014,14 @@ describe("TokenStaking", () => {
         ])
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           beneficiary.address,
           authorizer.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(0)
       })
 
@@ -3147,14 +3151,14 @@ describe("TokenStaking", () => {
         ])
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           staker.address,
           staker.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(blockTimestamp)
       })
 
@@ -3180,12 +3184,14 @@ describe("TokenStaking", () => {
       const keepAmount = initialStakerBalance.mul(2)
       const keepInTAmount = convertToT(keepAmount, keepRatio).result
       let tx
+      let blockTimestamp
 
       beforeEach(async () => {
         await nucypherStakingMock.setStaker(staker.address, nuAmount)
         await tokenStaking
           .connect(staker)
           .stakeNu(operator.address, staker.address, staker.address)
+        blockTimestamp = await lastBlockTime()
 
         const createdAt = 1
         await keepStakingMock.setOperator(
@@ -3213,15 +3219,15 @@ describe("TokenStaking", () => {
         ])
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           staker.address,
           staker.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
-        ).to.equal(0)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
+        ).to.equal(blockTimestamp)
       })
 
       it("should increase available amount to authorize", async () => {
@@ -3308,12 +3314,14 @@ describe("TokenStaking", () => {
       const newNuAmount = initialStakerBalance.mul(2)
       const newNuInTAmount = convertToT(newNuAmount, nuRatio).result
       let tx
+      let blockTimestamp
 
       beforeEach(async () => {
         await nucypherStakingMock.setStaker(staker.address, initialNuAmount)
         await tokenStaking
           .connect(staker)
           .stakeNu(operator.address, staker.address, staker.address)
+        blockTimestamp = await lastBlockTime()
         await tokenStaking
           .connect(staker)
           .delegateVoting(operator.address, delegatee.address)
@@ -3332,15 +3340,15 @@ describe("TokenStaking", () => {
         )
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           staker.address,
           staker.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
-        ).to.equal(0)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
+        ).to.equal(blockTimestamp)
       })
 
       it("should increase available amount to authorize", async () => {
@@ -3388,12 +3396,16 @@ describe("TokenStaking", () => {
       const nuAmount = initialStakerBalance
       const nuInTAmount = convertToT(nuAmount, nuRatio).result
       let tx
+      let blockTimestamp
 
       beforeEach(async () => {
         await nucypherStakingMock.setStaker(staker.address, nuAmount)
         await tokenStaking
           .connect(staker)
           .stakeNu(operator.address, staker.address, staker.address)
+        blockTimestamp = await lastBlockTime()
+        const oneDay = 86400
+        await ethers.provider.send("evm_increaseTime", [oneDay])
         await tokenStaking
           .connect(staker)
           .unstakeNu(operator.address, nuInTAmount)
@@ -3407,6 +3419,9 @@ describe("TokenStaking", () => {
           nuInTAmount,
         ])
         expect(await tokenStaking.stakedNu(operator.address)).to.equal(nuAmount)
+        expect(
+          await tokenStaking.getStartStakingTimestamp(operator.address)
+        ).to.equal(blockTimestamp)
       })
 
       it("should emit ToppedUp event", async () => {
@@ -3446,14 +3461,14 @@ describe("TokenStaking", () => {
         )
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           staker.address,
           staker.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(blockTimestamp)
       })
 
@@ -3520,14 +3535,14 @@ describe("TokenStaking", () => {
         )
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           beneficiary.address,
           authorizer.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(0)
       })
 
@@ -3689,11 +3704,9 @@ describe("TokenStaking", () => {
     context(
       "when unstake small amount before minimum staking time passes",
       () => {
-        const nuAmount = initialStakerBalance
-        const nuInTAmount = convertToT(nuAmount, nuRatio).result
         const amount = initialStakerBalance
         const minAmount = amount.div(3)
-        const authorized = minAmount.div(2).add(nuInTAmount)
+        const authorized = minAmount.div(2)
         const amountToUnstake = amount.sub(minAmount)
         let tx
         let blockTimestamp
@@ -3713,8 +3726,7 @@ describe("TokenStaking", () => {
               amount
             )
           blockTimestamp = await lastBlockTime()
-          await nucypherStakingMock.setStaker(staker.address, nuAmount)
-          await tokenStaking.connect(staker).topUpNu(operator.address)
+
           await tokenStaking
             .connect(authorizer)
             .increaseAuthorization(
@@ -3732,18 +3744,18 @@ describe("TokenStaking", () => {
           expect(await tokenStaking.stakes(operator.address)).to.deep.equal([
             minAmount,
             Zero,
-            nuInTAmount,
+            Zero,
           ])
         })
 
-        it("should not update roles and start T staking timestamp", async () => {
+        it("should not update roles and start staking timestamp", async () => {
           expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
             staker.address,
             beneficiary.address,
             authorizer.address,
           ])
           expect(
-            await tokenStaking.getStartTStakingTimestamp(operator.address)
+            await tokenStaking.getStartStakingTimestamp(operator.address)
           ).to.equal(blockTimestamp)
         })
 
@@ -3762,16 +3774,16 @@ describe("TokenStaking", () => {
               operator.address,
               application1Mock.address
             )
-          ).to.equal(minAmount.add(nuInTAmount).sub(authorized))
+          ).to.equal(minAmount.sub(authorized))
         })
 
-        it("should update min staked amount", async () => {
+        it("should not update min staked amount", async () => {
           expect(
             await tokenStaking.getMinStaked(operator.address, StakeTypes.T)
-          ).to.equal(authorized.sub(nuInTAmount))
+          ).to.equal(authorized)
           expect(
             await tokenStaking.getMinStaked(operator.address, StakeTypes.NU)
-          ).to.equal(authorized.sub(minAmount))
+          ).to.equal(0)
           expect(
             await tokenStaking.getMinStaked(operator.address, StakeTypes.KEEP)
           ).to.equal(0)
@@ -3819,14 +3831,14 @@ describe("TokenStaking", () => {
         ])
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           beneficiary.address,
           authorizer.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(blockTimestamp)
       })
 
@@ -3845,16 +3857,30 @@ describe("TokenStaking", () => {
     context("when initially T was topped-up", () => {
       const amount = initialStakerBalance
       const minAmount = initialStakerBalance.div(3)
-      const nuAmount = initialStakerBalance
-      const nuInTAmount = convertToT(nuAmount, nuRatio).result
+      const keepAmount = initialStakerBalance
+      const keepInTAmount = convertToT(keepAmount, keepRatio).result
       let tx
 
       beforeEach(async () => {
         await tokenStaking.connect(deployer).setMinimumStakeAmount(minAmount)
-        await nucypherStakingMock.setStaker(staker.address, nuAmount)
-        await tokenStaking
-          .connect(staker)
-          .stakeNu(operator.address, beneficiary.address, authorizer.address)
+
+        const createdAt = 1
+        await keepStakingMock.setOperator(
+          operator.address,
+          staker.address,
+          beneficiary.address,
+          authorizer.address,
+          createdAt,
+          0,
+          keepAmount
+        )
+        await keepStakingMock.setEligibility(
+          operator.address,
+          tokenStaking.address,
+          true
+        )
+        await tokenStaking.stakeKeep(operator.address)
+
         await tokenStaking
           .connect(staker)
           .delegateVoting(operator.address, delegatee.address)
@@ -3869,38 +3895,138 @@ describe("TokenStaking", () => {
       it("should update T staked amount", async () => {
         expect(await tokenStaking.stakes(operator.address)).to.deep.equal([
           Zero,
+          keepInTAmount,
           Zero,
-          nuInTAmount,
         ])
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           beneficiary.address,
           authorizer.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(0)
       })
 
       it("should decrease the delegatee voting power", async () => {
         expect(await tokenStaking.getVotes(delegatee.address)).to.equal(
-          nuInTAmount
+          keepInTAmount
         )
       })
 
       it("should decrease the total voting power", async () => {
         const lastBlock = await mineBlocks(1)
         expect(await tokenStaking.getPastTotalSupply(lastBlock - 1)).to.equal(
-          nuInTAmount
+          keepInTAmount
         )
       })
 
       it("should transfer tokens to the staker address", async () => {
         expect(await tToken.balanceOf(tokenStaking.address)).to.equal(0)
         expect(await tToken.balanceOf(staker.address)).to.equal(amount)
+      })
+
+      it("should emit Unstaked", async () => {
+        await expect(tx)
+          .to.emit(tokenStaking, "Unstaked")
+          .withArgs(operator.address, amount)
+      })
+    })
+
+    context("when Nu was topped-up", () => {
+      const amount = initialStakerBalance
+      const minAmount = initialStakerBalance.div(3)
+      const nuAmount = initialStakerBalance
+      const nuInTAmount = convertToT(nuAmount, nuRatio).result
+      let tx
+
+      beforeEach(async () => {
+        await tokenStaking.connect(deployer).setMinimumStakeAmount(minAmount)
+
+        await tToken.connect(staker).approve(tokenStaking.address, amount)
+        await tokenStaking
+          .connect(staker)
+          .stake(
+            operator.address,
+            beneficiary.address,
+            authorizer.address,
+            amount
+          )
+
+        await nucypherStakingMock.setStaker(staker.address, nuAmount)
+        await tokenStaking.connect(staker).topUpNu(operator.address)
+
+        tx = await tokenStaking
+          .connect(operator)
+          .unstakeT(operator.address, amount)
+      })
+
+      it("should update T staked amount", async () => {
+        expect(await tokenStaking.stakes(operator.address)).to.deep.equal([
+          Zero,
+          Zero,
+          nuInTAmount,
+        ])
+      })
+
+      it("should emit Unstaked", async () => {
+        await expect(tx)
+          .to.emit(tokenStaking, "Unstaked")
+          .withArgs(operator.address, amount)
+      })
+    })
+
+    context("when Keep was topped-up", () => {
+      const amount = initialStakerBalance
+      const minAmount = initialStakerBalance.div(3)
+      const keepAmount = initialStakerBalance
+      const keepInTAmount = convertToT(keepAmount, keepRatio).result
+      let tx
+
+      beforeEach(async () => {
+        await tokenStaking.connect(deployer).setMinimumStakeAmount(minAmount)
+
+        await tToken.connect(staker).approve(tokenStaking.address, amount)
+        await tokenStaking
+          .connect(staker)
+          .stake(
+            operator.address,
+            beneficiary.address,
+            authorizer.address,
+            amount
+          )
+
+        const createdAt = 1
+        await keepStakingMock.setOperator(
+          operator.address,
+          staker.address,
+          beneficiary.address,
+          authorizer.address,
+          createdAt,
+          0,
+          keepAmount
+        )
+        await keepStakingMock.setEligibility(
+          operator.address,
+          tokenStaking.address,
+          true
+        )
+        await tokenStaking.connect(staker).topUpKeep(operator.address)
+
+        tx = await tokenStaking
+          .connect(operator)
+          .unstakeT(operator.address, amount)
+      })
+
+      it("should update T staked amount", async () => {
+        expect(await tokenStaking.stakes(operator.address)).to.deep.equal([
+          Zero,
+          keepInTAmount,
+          Zero,
+        ])
       })
 
       it("should emit Unstaked", async () => {
@@ -4063,14 +4189,14 @@ describe("TokenStaking", () => {
         ])
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           beneficiary.address,
           authorizer.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(0)
       })
 
@@ -4135,6 +4261,52 @@ describe("TokenStaking", () => {
         await expect(
           tokenStaking.connect(authorizer).unstakeNu(operator.address, 0)
         ).to.be.revertedWith("Not owner or operator")
+      })
+    })
+
+    context(
+      "when unstake before minimum staking time passes with small T stake",
+      () => {
+        const nuAmount = initialStakerBalance
+        const nuInTAmount = convertToT(nuAmount, nuRatio).result
+
+        it("should revert", async () => {
+          await nucypherStakingMock.setStaker(staker.address, nuAmount)
+          await tokenStaking
+            .connect(staker)
+            .stakeNu(operator.address, beneficiary.address, authorizer.address)
+
+          await tToken.connect(staker).approve(tokenStaking.address, 1)
+          await tokenStaking.connect(staker).topUp(operator.address, 1)
+          await tokenStaking.connect(deployer).setMinimumStakeAmount(2)
+
+          await expect(
+            tokenStaking
+              .connect(operator)
+              .unstakeNu(operator.address, nuInTAmount)
+          ).to.be.revertedWith("Can't unstake earlier than 24h")
+        })
+      }
+    )
+
+    context("when unstake before minimum staking time passes", () => {
+      const nuAmount = initialStakerBalance
+      const nuInTAmount = convertToT(nuAmount, nuRatio).result
+
+      it("should revert", async () => {
+        await nucypherStakingMock.setStaker(staker.address, nuAmount)
+        await tokenStaking
+          .connect(staker)
+          .stakeNu(operator.address, beneficiary.address, authorizer.address)
+
+        await tToken.connect(staker).approve(tokenStaking.address, 1)
+        await tokenStaking.connect(staker).topUp(operator.address, 1)
+
+        await expect(
+          tokenStaking
+            .connect(operator)
+            .unstakeNu(operator.address, nuInTAmount)
+        ).to.be.revertedWith("Can't unstake earlier than 24h")
       })
     })
 
@@ -4235,8 +4407,10 @@ describe("TokenStaking", () => {
       const expectedNuInTAmount = convertToT(expectedNuAmount, nuRatio).result
       const expectedUnstaked = nuInTAmount.sub(expectedNuInTAmount)
       let tx
+      let blockTimestamp
 
       beforeEach(async () => {
+        await tokenStaking.connect(deployer).setMinimumStakeAmount(1)
         await tokenStaking
           .connect(deployer)
           .approveApplication(application1Mock.address)
@@ -4244,6 +4418,7 @@ describe("TokenStaking", () => {
         await tokenStaking
           .connect(staker)
           .stakeNu(operator.address, beneficiary.address, authorizer.address)
+        blockTimestamp = await lastBlockTime()
         await tokenStaking
           .connect(staker)
           .delegateVoting(operator.address, delegatee.address)
@@ -4274,15 +4449,15 @@ describe("TokenStaking", () => {
         )
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           beneficiary.address,
           authorizer.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
-        ).to.equal(0)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
+        ).to.equal(blockTimestamp)
       })
 
       it("should decrease available amount to authorize", async () => {
@@ -4362,7 +4537,7 @@ describe("TokenStaking", () => {
             .unstakeNu(operator.address, amountToUnstake)
         })
 
-        it("should ypdate Nu staked amount", async () => {
+        it("should update Nu staked amount", async () => {
           expect(await tokenStaking.stakes(operator.address)).to.deep.equal([
             Zero,
             Zero,
@@ -4380,6 +4555,92 @@ describe("TokenStaking", () => {
         })
       }
     )
+
+    context("when Keep was topped-up", () => {
+      const nuAmount = initialStakerBalance
+      const nuInTAmount = convertToT(nuAmount, nuRatio).result
+      const keepAmount = initialStakerBalance
+      const keepInTAmount = convertToT(keepAmount, keepRatio).result
+      let tx
+
+      beforeEach(async () => {
+        await nucypherStakingMock.setStaker(staker.address, nuAmount)
+        await tokenStaking
+          .connect(staker)
+          .stakeNu(operator.address, beneficiary.address, authorizer.address)
+
+        const createdAt = 1
+        await keepStakingMock.setOperator(
+          operator.address,
+          staker.address,
+          beneficiary.address,
+          authorizer.address,
+          createdAt,
+          0,
+          keepAmount
+        )
+        await keepStakingMock.setEligibility(
+          operator.address,
+          tokenStaking.address,
+          true
+        )
+        await tokenStaking.connect(staker).topUpKeep(operator.address)
+
+        tx = await tokenStaking
+          .connect(operator)
+          .unstakeNu(operator.address, nuInTAmount)
+      })
+
+      it("should update Nu staked amount", async () => {
+        expect(await tokenStaking.stakes(operator.address)).to.deep.equal([
+          Zero,
+          keepInTAmount,
+          Zero,
+        ])
+        expect(await tokenStaking.stakedNu(operator.address)).to.equal(0)
+      })
+
+      it("should emit Unstaked", async () => {
+        await expect(tx)
+          .to.emit(tokenStaking, "Unstaked")
+          .withArgs(operator.address, nuInTAmount)
+      })
+    })
+
+    context("when unstake after minimum staking time passes", () => {
+      const nuAmount = initialStakerBalance
+      const nuInTAmount = convertToT(nuAmount, nuRatio).result
+      let tx
+
+      beforeEach(async () => {
+        await nucypherStakingMock.setStaker(staker.address, nuAmount)
+        await tokenStaking
+          .connect(staker)
+          .stakeNu(operator.address, beneficiary.address, authorizer.address)
+
+        const oneDay = 86400
+        await ethers.provider.send("evm_increaseTime", [oneDay])
+
+        tx = await tokenStaking
+          .connect(operator)
+          .unstakeNu(operator.address, nuInTAmount)
+      })
+
+      it("should update Nu staked amount", async () => {
+        expect(await tokenStaking.stakes(operator.address)).to.deep.equal([
+          Zero,
+          Zero,
+          Zero,
+        ])
+        expect(await tokenStaking.stakedNu(operator.address)).to.equal(0)
+      })
+
+      it("should emit Unstaked", async () => {
+        await expect(tx)
+          .to.emit(tokenStaking, "Unstaked")
+          .withArgs(operator.address, nuInTAmount)
+      })
+    })
   })
 
   describe("unstakeAll", () => {
@@ -4461,8 +4722,26 @@ describe("TokenStaking", () => {
       })
     })
 
-    const contextUnstakeAll = (preparation, tAmount, isCallerStaker) => {
-      const nuAmount = initialStakerBalance
+    context("when unstake Nu before minimum staking time passes", () => {
+      it("should revert", async () => {
+        const nuAmount = initialStakerBalance
+        await nucypherStakingMock.setStaker(staker.address, nuAmount)
+        await tokenStaking
+          .connect(staker)
+          .stakeNu(operator.address, beneficiary.address, authorizer.address)
+
+        await expect(
+          tokenStaking.connect(staker).unstakeAll(operator.address)
+        ).to.be.revertedWith("Can't unstake earlier than 24h")
+      })
+    })
+
+    const contextUnstakeAll = (
+      preparation,
+      tAmount,
+      nuAmount,
+      isCallerStaker
+    ) => {
       const nuInTAmount = convertToT(nuAmount, nuRatio).result
       const keepAmount = initialStakerBalance
       const keepInTAmount = convertToT(keepAmount, keepRatio).result
@@ -4470,7 +4749,7 @@ describe("TokenStaking", () => {
       let blockTimestamp
 
       beforeEach(async () => {
-        blockTimestamp = await preparation(nuAmount, keepAmount)
+        blockTimestamp = await preparation(keepAmount)
 
         tx = await tokenStaking
           .connect(isCallerStaker ? staker : operator)
@@ -4485,14 +4764,14 @@ describe("TokenStaking", () => {
         ])
       })
 
-      it("should not update roles and start T staking timestamp", async () => {
+      it("should not update roles and start staking timestamp", async () => {
         expect(await tokenStaking.rolesOf(operator.address)).to.deep.equal([
           staker.address,
           beneficiary.address,
           authorizer.address,
         ])
         expect(
-          await tokenStaking.getStartTStakingTimestamp(operator.address)
+          await tokenStaking.getStartStakingTimestamp(operator.address)
         ).to.equal(blockTimestamp)
       })
 
@@ -4534,9 +4813,24 @@ describe("TokenStaking", () => {
       })
     }
 
-    context("when stake is only in Keep and Nu", () => {
+    context("when stake is only in Keep", () => {
+      const tAmount = initialStakerBalance
+
       contextUnstakeAll(
-        async (nuAmount, keepAmount) => {
+        async (keepAmount) => {
+          await tokenStaking.connect(deployer).setMinimumStakeAmount(1)
+
+          await tToken.connect(staker).approve(tokenStaking.address, tAmount)
+          await tokenStaking
+            .connect(staker)
+            .stake(
+              operator.address,
+              beneficiary.address,
+              authorizer.address,
+              tAmount
+            )
+          const blockTimestamp = await lastBlockTime()
+
           const createdAt = 1
           await keepStakingMock.setOperator(
             operator.address,
@@ -4552,12 +4846,12 @@ describe("TokenStaking", () => {
             tokenStaking.address,
             true
           )
-          await tokenStaking.stakeKeep(operator.address)
+          await tokenStaking.connect(staker).topUpKeep(operator.address)
+          await tokenStaking.connect(staker).unstakeT(operator.address, tAmount)
 
-          await nucypherStakingMock.setStaker(staker.address, nuAmount)
-          await tokenStaking.connect(staker).topUpNu(operator.address)
-          return 0
+          return blockTimestamp
         },
+        0,
         0,
         true
       )
@@ -4567,7 +4861,7 @@ describe("TokenStaking", () => {
       const tAmount = initialStakerBalance
 
       contextUnstakeAll(
-        async (nuAmount, keepAmount) => {
+        async (keepAmount) => {
           await tokenStaking
             .connect(deployer)
             .approveApplication(application1Mock.address)
@@ -4600,9 +4894,6 @@ describe("TokenStaking", () => {
           )
           await tokenStaking.connect(staker).topUpKeep(operator.address)
 
-          await nucypherStakingMock.setStaker(staker.address, nuAmount)
-          await tokenStaking.connect(staker).topUpNu(operator.address)
-
           const authorized = tAmount
           await tokenStaking
             .connect(authorizer)
@@ -4619,15 +4910,17 @@ describe("TokenStaking", () => {
           return blockTimestamp
         },
         tAmount,
+        0,
         true
       )
     })
 
     context("when initially T was topped-up", () => {
       const tAmount = initialStakerBalance
+      const nuAmount = initialStakerBalance
 
       contextUnstakeAll(
-        async (nuAmount, keepAmount) => {
+        async (keepAmount) => {
           await tokenStaking
             .connect(deployer)
             .approveApplication(application1Mock.address)
@@ -4659,60 +4952,117 @@ describe("TokenStaking", () => {
           return 0
         },
         tAmount,
+        nuAmount,
         false
       )
     })
 
-    context("when unstake after minimum staking time passes", () => {
-      const tAmount = initialStakerBalance
+    context(
+      "when unstake after minimum staking time passes for T stake",
+      () => {
+        const tAmount = initialStakerBalance
+        const nuAmount = initialStakerBalance
 
-      contextUnstakeAll(
-        async (nuAmount, keepAmount) => {
-          await tokenStaking
-            .connect(deployer)
-            .approveApplication(application1Mock.address)
-          await tokenStaking.connect(deployer).setMinimumStakeAmount(1)
+        contextUnstakeAll(
+          async (keepAmount) => {
+            await tokenStaking
+              .connect(deployer)
+              .approveApplication(application1Mock.address)
+            await tokenStaking.connect(deployer).setMinimumStakeAmount(1)
 
-          await tToken.connect(staker).approve(tokenStaking.address, tAmount)
-          await tokenStaking
-            .connect(staker)
-            .stake(
+            await tToken.connect(staker).approve(tokenStaking.address, tAmount)
+            await tokenStaking
+              .connect(staker)
+              .stake(
+                operator.address,
+                beneficiary.address,
+                authorizer.address,
+                tAmount
+              )
+            const blockTimestamp = await lastBlockTime()
+
+            const oneDay = 86400
+            await ethers.provider.send("evm_increaseTime", [oneDay])
+
+            const createdAt = 1
+            await keepStakingMock.setOperator(
               operator.address,
+              staker.address,
               beneficiary.address,
               authorizer.address,
-              tAmount
+              createdAt,
+              0,
+              keepAmount
             )
-          const blockTimestamp = await lastBlockTime()
+            await keepStakingMock.setEligibility(
+              operator.address,
+              tokenStaking.address,
+              true
+            )
+            await tokenStaking.connect(staker).topUpKeep(operator.address)
 
-          const createdAt = 1
-          await keepStakingMock.setOperator(
-            operator.address,
-            staker.address,
-            beneficiary.address,
-            authorizer.address,
-            createdAt,
-            0,
-            keepAmount
-          )
-          await keepStakingMock.setEligibility(
-            operator.address,
-            tokenStaking.address,
-            true
-          )
-          await tokenStaking.connect(staker).topUpKeep(operator.address)
+            await nucypherStakingMock.setStaker(staker.address, nuAmount)
+            await tokenStaking.connect(staker).topUpNu(operator.address)
 
-          await nucypherStakingMock.setStaker(staker.address, nuAmount)
-          await tokenStaking.connect(staker).topUpNu(operator.address)
+            return blockTimestamp
+          },
+          tAmount,
+          nuAmount,
+          false
+        )
+      }
+    )
 
-          const oneDay = 86400
-          await ethers.provider.send("evm_increaseTime", [oneDay])
+    context(
+      "when unstake after minimum staking time passes for NU stake",
+      () => {
+        const nuAmount = initialStakerBalance
 
-          return blockTimestamp
-        },
-        tAmount,
-        false
-      )
-    })
+        contextUnstakeAll(
+          async (keepAmount) => {
+            await tokenStaking
+              .connect(deployer)
+              .approveApplication(application1Mock.address)
+            await tokenStaking.connect(deployer).setMinimumStakeAmount(1)
+
+            await nucypherStakingMock.setStaker(staker.address, nuAmount)
+            await tokenStaking
+              .connect(staker)
+              .stakeNu(
+                operator.address,
+                beneficiary.address,
+                authorizer.address
+              )
+            const blockTimestamp = await lastBlockTime()
+
+            const createdAt = 1
+            await keepStakingMock.setOperator(
+              operator.address,
+              staker.address,
+              beneficiary.address,
+              authorizer.address,
+              createdAt,
+              0,
+              keepAmount
+            )
+            await keepStakingMock.setEligibility(
+              operator.address,
+              tokenStaking.address,
+              true
+            )
+            await tokenStaking.connect(staker).topUpKeep(operator.address)
+
+            const oneDay = 86400
+            await ethers.provider.send("evm_increaseTime", [oneDay])
+
+            return blockTimestamp
+          },
+          0,
+          nuAmount,
+          false
+        )
+      }
+    )
   })
 
   describe("notifyKeepStakeDiscrepancy", () => {


### PR DESCRIPTION
Adds restriction to `unstakeNu`/`unstakeAll`, same as in `unstakeT`.
Besides that softened restrictions for Keep stakers: no need to check timestamp because operator address protected in Keep staking contract.