### PR TITLE
Replace postinstall with prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "contracts/",
     "!**/test/",
     "deploy/",
+    "export/",
     "export.json"
   ],
   "scripts": {
@@ -23,8 +24,8 @@
     "lint:sol": "solhint 'contracts/**/*.sol'",
     "test": "hardhat test",
     "test:system": "NODE_ENV=system-test hardhat test ./test/system/*.test.js",
-    "prepublishOnly": "./scripts/prepare-artifacts.sh --network $npm_config_network",
-    "postinstall": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts"
+    "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts",
+    "prepublishOnly": "./scripts/prepare-artifacts.sh --network $npm_config_network"
   },
   "devDependencies": {
     "@keep-network/hardhat-helpers": "^0.4.1-pre.2",


### PR DESCRIPTION
The script we want to execute is transpiling the code from TS to JS.
The `postinstall` script worked fine if we used the repostiory as github
dependency in a package, but was failing if we used the NPM package
dependency.
According to YARN documentation for transpiling the recommended script
is `prepack` which should work fine in both cases.
See: https://yarnpkg.com/advanced/lifecycle-scripts