### PR TITLE
Fix deployment scripts for networks tagged as local

### DIFF
--- a/deploy/00_resolve_nucypher_staking_escrow.ts
+++ b/deploy/00_resolve_nucypher_staking_escrow.ts
@@ -27,7 +27,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // TODO: For ropsten currently we deploy a stub contract. We should consider
     // switching to an actual contract.
     hre.network.name !== "ropsten" &&
-    (hre.network.name !== "hardhat" ||
+    (!hre.network.tags.local ||
       (hre.network.config as HardhatNetworkConfig).forking.enabled)
   ) {
     throw new Error("deployed NuCypherStakingEscrow contract not found")

--- a/deploy/00_resolve_nucypher_token.ts
+++ b/deploy/00_resolve_nucypher_token.ts
@@ -22,7 +22,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // TODO: For ropsten currently we deploy a stub contract. We should consider
     // switching to an actual contract.
     hre.network.name !== "ropsten" &&
-    (hre.network.name !== "hardhat" ||
+    (!hre.network.tags.local ||
       (hre.network.config as HardhatNetworkConfig).forking.enabled)
   ) {
     throw new Error("deployed NuCypherToken contract not found")


### PR DESCRIPTION
For networks tagged as `local` we want to deploy stub contracts.