### PR TITLE
Add scripts directory to NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@keep-network/keep-core": "^1.8.0-dev.4",
+    "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
     "@openzeppelin/contracts": "^4.4",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "!**/test/",
     "deploy/",
     "export/",
+    "scripts/",
     "export.json"
   ],
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,7 +577,7 @@
     deepmerge "^4.2.2"
     untildify "^4.0.0"
 
-"@keep-network/keep-core@^1.8.0-dev.4":
+"@keep-network/keep-core@>1.8.0-dev <1.8.0-pre":
   version "1.8.0-dev.5"
   resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.0-dev.5.tgz#8b4d08ec437f29c94723ee54fcf76456ba5408c3"
   integrity sha512-QVkpO5X28Vczj/xHezV0z2UuMw8QFaR3C8x/d6+3adedsL3nCxgveIGTUcXSuYpBqfx0v4/xT+9bIK7BwLkGPw==


### PR DESCRIPTION
We need to include the scripts directory as it contains files that are
executed as part of NPM scripts, i.e. `postinstall`.

Another change in this PR is the range for `@keep-network/keep-core` dependency. We should have a range specific for development packages. The previous solution was pulling packages for ropsten.