### PR TITLE
Removed wrapped and T token allocation validation against total supplies

### DIFF
--- a/contracts/vending/VendingMachine.sol
+++ b/contracts/vending/VendingMachine.sol
@@ -97,11 +97,6 @@ contract VendingMachine is IReceiveApproval {
         uint96 _wrappedTokenAllocation,
         uint96 _tTokenAllocation
     ) {
-        require(
-            _tToken.totalSupply() >= _tTokenAllocation &&
-                _wrappedToken.totalSupply() >= _wrappedTokenAllocation,
-            "Allocations can't be greater than token supplies"
-        );
         wrappedToken = _wrappedToken;
         tToken = _tToken;
         ratio =


### PR DESCRIPTION
Refs #53 

We want to deploy Vending Machines before T supply is minted.
This requires removing the validation.

The deployer needs to be an adult knowing what they are doing.