### PR TITLE
1.0.0/1.1.0-dev version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threshold-network/solidity-contracts",
-  "version": "0.0.2-dev",
+  "version": "1.1.0-dev",
   "license": "GPL-3.0-or-later",
   "files": [
     "artifacts/",


### PR DESCRIPTION
Refs https://github.com/threshold-network/solidity-contracts/issues/53

Updating versions after `v1.0.0` release.

`65c092d0e880759ca2339967e2fb32b741258470` from `releases/mainnet/v1.0.0` will be tagged as `v1.0.0`