### PR TITLE
Fix deployment scripts

### DIFF
--- a/deploy/00_resolve_nucypher_staking_escrow.ts
+++ b/deploy/00_resolve_nucypher_staking_escrow.ts
@@ -28,7 +28,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // switching to an actual contract.
     hre.network.name !== "ropsten" &&
     (!hre.network.tags.local ||
-      (hre.network.config as HardhatNetworkConfig).forking.enabled)
+      (hre.network.config as HardhatNetworkConfig).forking?.enabled)
   ) {
     throw new Error("deployed NuCypherStakingEscrow contract not found")
   } else {

--- a/deploy/00_resolve_nucypher_token.ts
+++ b/deploy/00_resolve_nucypher_token.ts
@@ -23,7 +23,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // switching to an actual contract.
     hre.network.name !== "ropsten" &&
     (!hre.network.tags.local ||
-      (hre.network.config as HardhatNetworkConfig).forking.enabled)
+      (hre.network.config as HardhatNetworkConfig).forking?.enabled)
   ) {
     throw new Error("deployed NuCypherToken contract not found")
   } else {


### PR DESCRIPTION
Some network settings do not include the `forking` field so we should
use `optional chaining` whenever we want to get some value from the
`forking` field.

`(hre.network.config as HardhatNetworkConfig).forking.enabled)` ->
`(hre.network.config as HardhatNetworkConfig).forking?.enabled)`