### PR TITLE
Upgradeability logic for TokenStaking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ yarn-error.log
 
 .hardhat/*
 !.hardhat/networks_TEMPLATE.ts
+
+# OpenZeppelin
+.openzeppelin/unknown-*.json

--- a/.solhint.json
+++ b/.solhint.json
@@ -2,6 +2,7 @@
   "extends": "keep",
   "plugins": [],
   "rules": {
+    "max-states-count": ["warn", 20],
     "func-visibility": ["error", { "ignoreConstructors": true }],
     "no-inline-assembly": "off"
   }

--- a/contracts/governance/Checkpoints.sol
+++ b/contracts/governance/Checkpoints.sol
@@ -43,6 +43,7 @@ abstract contract Checkpoints is IVotesHistory {
     // Reserved storage space in case we need to add more variables,
     // since there are upgradeable contracts that inherit from this one.
     // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+    // slither-disable-next-line unused-state
     uint256[47] private __gap;
 
     /// @notice Emitted when an account changes their delegate.

--- a/contracts/governance/Checkpoints.sol
+++ b/contracts/governance/Checkpoints.sol
@@ -16,9 +16,8 @@
 pragma solidity 0.8.9;
 
 import "./IVotesHistory.sol";
-import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 
 /// @title Checkpoints
 /// @dev Abstract contract to support checkpoints for Compound-like voting and
@@ -74,7 +73,7 @@ abstract contract Checkpoints is IVotesHistory {
         virtual
         returns (uint32)
     {
-        return SafeCast.toUint32(_checkpoints[account].length);
+        return SafeCastUpgradeable.toUint32(_checkpoints[account].length);
     }
 
     /// @notice Get the address `account` is currently delegating to.
@@ -179,7 +178,7 @@ abstract contract Checkpoints is IVotesHistory {
             if (fromBlock == block.number) {
                 ckpts[pos - 1] = encodeCheckpoint(
                     fromBlock,
-                    SafeCast.toUint96(newWeight)
+                    SafeCastUpgradeable.toUint96(newWeight)
                 );
                 return (oldWeight, newWeight);
             }
@@ -187,8 +186,8 @@ abstract contract Checkpoints is IVotesHistory {
 
         ckpts.push(
             encodeCheckpoint(
-                SafeCast.toUint32(block.number),
-                SafeCast.toUint96(newWeight)
+                SafeCastUpgradeable.toUint32(block.number),
+                SafeCastUpgradeable.toUint96(newWeight)
             )
         );
     }
@@ -222,7 +221,7 @@ abstract contract Checkpoints is IVotesHistory {
         uint256 high = ckpts.length;
         uint256 low = 0;
         while (low < high) {
-            uint256 mid = Math.average(low, high);
+            uint256 mid = MathUpgradeable.average(low, high);
             uint32 midBlock = decodeBlockNumber(ckpts[mid]);
             if (midBlock > blockNumber) {
                 high = mid;

--- a/contracts/governance/Checkpoints.sol
+++ b/contracts/governance/Checkpoints.sol
@@ -28,6 +28,7 @@ import "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 ///      {delegateBySig}. Voting power can be publicly queried through
 ///      {getVotes} and {getPastVotes}.
 ///      NOTE: Extracted from OpenZeppelin ERCVotes.sol.
+/// @dev This contract is upgrade-safe.
 abstract contract Checkpoints is IVotesHistory {
     struct Checkpoint {
         uint32 fromBlock;
@@ -38,6 +39,11 @@ abstract contract Checkpoints is IVotesHistory {
     mapping(address => address) internal _delegates;
     mapping(address => uint128[]) internal _checkpoints;
     uint128[] internal _totalSupplyCheckpoints;
+
+    // Reserved storage space in case we need to add more variables,
+    // since there are upgradeable contracts that inherit from this one.
+    // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+    uint256[47] private __gap;
 
     /// @notice Emitted when an account changes their delegate.
     event DelegateChanged(

--- a/contracts/governance/ProxyAdminWithDeputy.sol
+++ b/contracts/governance/ProxyAdminWithDeputy.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity 0.8.9;
+
+import "./StakerGovernor.sol";
+import "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+
+/// @title ProxyAdminWithDeputy
+/// @notice Based on `ProxyAdmin`, an auxiliary contract in OpenZeppelin's
+///         upgradeability approach meant to act as the admin of a
+///         `TransparentUpgradeableProxy`. This variant allows an additional
+///         actor, the "deputy", to perform upgrades, which originally can only
+///         be performed by the ProxyAdmin's owner. See OpenZeppelin's
+///         documentation for `TransparentUpgradeableProxy` for more details on
+///         why a ProxyAdmin is recommended.
+contract ProxyAdminWithDeputy is ProxyAdmin {
+    address public deputy;
+    event DeputyUpdated(
+        address indexed previousDeputy,
+        address indexed newDeputy
+    );
+
+    modifier onlyOwnerOrDeputy() {
+        _checkCallerIsOwnerOrDeputy();
+        _;
+    }
+
+    constructor(StakerGovernor dao, address _deputy) {
+        address timelock = dao.timelock();
+        require(timelock != address(0), "DAO doesn't have a Timelock");
+        _setDeputy(_deputy);
+        _transferOwnership(timelock);
+    }
+
+    function setDeputy(address newDeputy) external onlyOwner {
+        _setDeputy(newDeputy);
+    }
+
+    /// @notice Upgrades `proxy` to `implementation`. This contract must be the
+    ///         admin of `proxy`, and the caller must be this contract's owner
+    ///         or the deputy.
+    function upgrade(TransparentUpgradeableProxy proxy, address implementation)
+        public
+        virtual
+        override
+        onlyOwnerOrDeputy
+    {
+        proxy.upgradeTo(implementation);
+    }
+
+    /// @notice Upgrades `proxy` to `implementation` and calls a function on the
+    ///         new implementation. This contract must be the admin of `proxy`,
+    ///         and the caller must be this contract's owner or the deputy.
+    function upgradeAndCall(
+        TransparentUpgradeableProxy proxy,
+        address implementation,
+        bytes memory data
+    ) public payable virtual override onlyOwnerOrDeputy {
+        proxy.upgradeToAndCall{value: msg.value}(implementation, data);
+    }
+
+    function _setDeputy(address newDeputy) internal {
+        address oldDeputy = deputy;
+        deputy = newDeputy;
+        emit DeputyUpdated(oldDeputy, newDeputy);
+    }
+
+    function _checkCallerIsOwnerOrDeputy() internal view {
+        address caller = _msgSender();
+        require(
+            owner() == caller || deputy == caller,
+            "Caller is neither the owner nor the deputy"
+        );
+    }
+}

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -180,10 +180,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         address indexed oldOwner,
         address indexed newOwner
     );
-    event GovernanceTransferred(
-        address indexed previousGovernance,
-        address indexed newGovernance
-    );
+    event GovernanceTransferred(address oldGovernance, address newGovernance);
 
     modifier onlyGovernance() {
         require(governance == msg.sender, "Caller is not the governance");

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -36,6 +36,10 @@ import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 ///         that run on the Threshold Network. Note that legacy NU/KEEP staking
 ///         contracts see TokenStaking as an application (e.g., slashing is
 ///         requested by TokenStaking and performed by the legacy contracts).
+/// @dev TokenStaking is upgradeable, using OpenZeppelin's Upgradeability
+///      framework. As such, it is required to satisfy OZ's guidelines, like
+///      restrictions on constructors, immutable variables, base contracts and
+///      libraries. See https://docs.openzeppelin.com/upgrades-plugins/1.x/writing-upgradeable
 contract TokenStaking is Initializable, IStaking, Checkpoints {
     using SafeTUpgradeable for T;
     using PercentUtils for uint256;

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -22,12 +22,12 @@ import "./KeepStake.sol";
 import "../governance/Checkpoints.sol";
 import "../token/T.sol";
 import "../utils/PercentUtils.sol";
+import "../utils/SafeT.sol";
 import "../vending/VendingMachine.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 
 /// @notice TokenStaking is the main staking contract of the Threshold Network.
 ///         Apart from the basic usage of enabling T stakes, it also acts as a
@@ -37,7 +37,7 @@ import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 ///         contracts see TokenStaking as an application (e.g., slashing is
 ///         requested by TokenStaking and performed by the legacy contracts).
 contract TokenStaking is Initializable, IStaking, Checkpoints {
-    using SafeERC20 for T;
+    using SafeT for T;
     using PercentUtils for uint256;
     using SafeCast for uint256;
 
@@ -231,7 +231,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
             _token.totalSupply() > 0 &&
                 _keepStakingContract.ownerOf(address(0)) == address(0) &&
                 _nucypherStakingContract.getAllTokens(address(0)) == 0 &&
-                Address.isContract(address(_keepStake)),
+                AddressUpgradeable.isContract(address(_keepStake)),
             "Wrong input parameters"
         );
         token = _token;

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -79,15 +79,14 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     uint256 internal constant SLASHING_REWARD_PERCENT = 5;
     uint256 internal constant MIN_STAKE_TIME = 24 hours;
     uint256 internal constant GAS_LIMIT_AUTHORIZATION_DECREASE = 250000;
+    uint256 internal constant CONVERSION_DIVISOR = 10**(18 - 3);
 
     T internal immutable token;
     IKeepTokenStaking internal immutable keepStakingContract;
     KeepStake internal immutable keepStake;
     INuCypherStakingEscrow internal immutable nucypherStakingContract;
 
-    uint256 internal immutable keepFloatingPointDivisor;
     uint256 internal immutable keepRatio;
-    uint256 internal immutable nucypherFloatingPointDivisor;
     uint256 internal immutable nucypherRatio;
 
     address public governance;
@@ -233,10 +232,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         keepStake = _keepStake;
         nucypherStakingContract = _nucypherStakingContract;
 
-        keepFloatingPointDivisor = _keepVendingMachine.FLOATING_POINT_DIVISOR();
         keepRatio = _keepVendingMachine.ratio();
-        nucypherFloatingPointDivisor = _nucypherVendingMachine
-            .FLOATING_POINT_DIVISOR();
         nucypherRatio = _nucypherVendingMachine.ratio();
     }
 
@@ -803,7 +799,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         OperatorInfo storage operatorStruct = operators[operator];
         // rounding amount to guarantee exact T<>NU conversion in both ways,
         // so there's no remainder after unstaking
-        (, uint96 tRemainder) = tToNu(amount);
+        (, uint96 tRemainder) = convertFromT(amount, nucypherRatio);
         amount -= tRemainder;
         require(
             amount > 0 &&
@@ -874,7 +870,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         (uint256 keepStakeAmount, , uint256 undelegatedAt) = keepStakingContract
             .getDelegationInfo(operator);
 
-        (uint96 realKeepInTStake, ) = keepToT(keepStakeAmount);
+        (uint96 realKeepInTStake, ) = convertToT(keepStakeAmount, keepRatio);
         uint96 oldKeepInTStake = operatorStruct.keepInTStake;
 
         require(
@@ -925,7 +921,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         uint256 nuStakeAmount = nucypherStakingContract.getAllTokens(
             operatorStruct.owner
         );
-        (uint96 realNuInTStake, ) = nuToT(nuStakeAmount);
+        (uint96 realNuInTStake, ) = convertToT(nuStakeAmount, nucypherRatio);
         uint96 oldNuInTStake = operatorStruct.nuInTStake;
         require(oldNuInTStake > realNuInTStake, "There is no discrepancy");
 
@@ -1130,7 +1126,10 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         override
         returns (uint256 nuAmount)
     {
-        (nuAmount, ) = tToNu(operators[operator].nuInTStake);
+        (nuAmount, ) = convertFromT(
+            operators[operator].nuInTStake,
+            nucypherRatio
+        );
     }
 
     /// @notice Gets the stake owner, the beneficiary and the authorizer
@@ -1387,7 +1386,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         if (tAmountToSlash > 0 && operatorStruct.keepInTStake > 0) {
             (uint256 keepStakeAmount, , ) = keepStakingContract
                 .getDelegationInfo(slashing.operator);
-            (uint96 tAmount, ) = keepToT(keepStakeAmount);
+            (uint96 tAmount, ) = convertToT(keepStakeAmount, keepRatio);
             operatorStruct.keepInTStake = tAmount;
 
             tAmountToSlash = seizeKeep(
@@ -1502,7 +1501,10 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
             tPenalty = operatorStruct.keepInTStake;
         }
 
-        (uint256 keepPenalty, uint96 tRemainder) = tToKeep(tPenalty);
+        (uint256 keepPenalty, uint96 tRemainder) = convertFromT(
+            tPenalty,
+            keepRatio
+        );
         if (keepPenalty == 0) {
             return tAmountToSlash;
         }
@@ -1540,7 +1542,10 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
             tPenalty = operatorStruct.nuInTStake;
         }
 
-        (uint256 nuPenalty, uint96 tRemainder) = tToNu(tPenalty);
+        (uint256 nuPenalty, uint96 tRemainder) = convertFromT(
+            tPenalty,
+            nucypherRatio
+        );
         if (nuPenalty == 0) {
             return tAmountToSlash;
         }
@@ -1647,7 +1652,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
             owner,
             operator
         );
-        (uint96 tAmount, ) = nuToT(nuStakeAmount);
+        (uint96 tAmount, ) = convertToT(nuStakeAmount, nucypherRatio);
         return tAmount;
     }
 
@@ -1664,60 +1669,33 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
             operator,
             address(this)
         );
-        (uint96 tAmount, ) = keepToT(keepStakeAmount);
+        (uint96 tAmount, ) = convertToT(keepStakeAmount, keepRatio);
         return tAmount;
     }
 
-    /// @notice Returns the T token amount that's obtained from `amount` wrapped
-    ///         tokens (KEEP), and the remainder that can't be converted.
-    function keepToT(uint256 keepAmount)
+    /// @notice Returns the T token amount that's obtained from `amount` legacy
+    ///         tokens for the given `ratio`, and the remainder that can't be
+    ///         converted.
+    function convertToT(uint256 amount, uint256 ratio)
         internal
-        view
-        returns (uint96 tAmount, uint256 keepRemainder)
+        pure
+        returns (uint96 tAmount, uint256 remainder)
     {
-        keepRemainder = keepAmount % keepFloatingPointDivisor;
-        uint256 convertibleAmount = keepAmount - keepRemainder;
-        tAmount = ((convertibleAmount * keepRatio) / keepFloatingPointDivisor)
-            .toUint96();
+        remainder = amount % CONVERSION_DIVISOR;
+        uint256 convertibleAmount = amount - remainder;
+        tAmount = ((convertibleAmount * ratio) / CONVERSION_DIVISOR).toUint96();
     }
 
-    /// @notice The amount of wrapped tokens (KEEP) that's obtained from
-    ///         `amount` T tokens, and the remainder that can't be converted.
-    function tToKeep(uint96 tAmount)
+    /// @notice Returns the amount of legacy tokens that's obtained from
+    ///         `tAmount` T tokens for the given `ratio`, and the T remainder
+    ///         that can't be converted.
+    function convertFromT(uint96 tAmount, uint256 ratio)
         internal
-        view
-        returns (uint256 keepAmount, uint96 tRemainder)
+        pure
+        returns (uint256 amount, uint96 tRemainder)
     {
-        tRemainder = (tAmount % keepRatio).toUint96();
+        tRemainder = (tAmount % ratio).toUint96();
         uint256 convertibleAmount = tAmount - tRemainder;
-        keepAmount = (convertibleAmount * keepFloatingPointDivisor) / keepRatio;
-    }
-
-    /// @notice Returns the T token amount that's obtained from `amount` wrapped
-    ///         tokens (NU), and the remainder that can't be converted.
-    function nuToT(uint256 nuAmount)
-        internal
-        view
-        returns (uint96 tAmount, uint256 nuRemainder)
-    {
-        nuRemainder = nuAmount % nucypherFloatingPointDivisor;
-        uint256 convertibleAmount = nuAmount - nuRemainder;
-        tAmount = ((convertibleAmount * nucypherRatio) /
-            nucypherFloatingPointDivisor).toUint96();
-    }
-
-    /// @notice The amount of wrapped tokens (NU) that's obtained from
-    ///         `amount` T tokens, and the remainder that can't be converted.
-    function tToNu(uint96 tAmount)
-        internal
-        view
-        returns (uint256 nuAmount, uint96 tRemainder)
-    {
-        //slither-disable-next-line weak-prng
-        tRemainder = (tAmount % nucypherRatio).toUint96();
-        uint256 convertibleAmount = tAmount - tRemainder;
-        nuAmount =
-            (convertibleAmount * nucypherFloatingPointDivisor) /
-            nucypherRatio;
+        amount = (convertibleAmount * CONVERSION_DIVISOR) / ratio;
     }
 }

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -22,7 +22,7 @@ import "./KeepStake.sol";
 import "../governance/Checkpoints.sol";
 import "../token/T.sol";
 import "../utils/PercentUtils.sol";
-import "../utils/SafeT.sol";
+import "../utils/SafeTUpgradeable.sol";
 import "../vending/VendingMachine.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/utils/math/SafeCast.sol";
@@ -37,7 +37,7 @@ import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 ///         contracts see TokenStaking as an application (e.g., slashing is
 ///         requested by TokenStaking and performed by the legacy contracts).
 contract TokenStaking is Initializable, IStaking, Checkpoints {
-    using SafeT for T;
+    using SafeTUpgradeable for T;
     using PercentUtils for uint256;
     using SafeCast for uint256;
 

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -24,8 +24,8 @@ import "../token/T.sol";
 import "../utils/PercentUtils.sol";
 import "../utils/SafeTUpgradeable.sol";
 import "../vending/VendingMachine.sol";
-import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts/utils/math/SafeCast.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/math/SafeCastUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 
@@ -43,7 +43,7 @@ import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
 contract TokenStaking is Initializable, IStaking, Checkpoints {
     using SafeTUpgradeable for T;
     using PercentUtils for uint256;
-    using SafeCast for uint256;
+    using SafeCastUpgradeable for uint256;
 
     enum ApplicationStatus {
         NOT_APPROVED,
@@ -1044,7 +1044,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         );
 
         uint256 maxIndex = slashingQueueIndex + count;
-        maxIndex = Math.min(maxIndex, slashingQueue.length);
+        maxIndex = MathUpgradeable.min(maxIndex, slashingQueue.length);
         count = maxIndex - slashingQueueIndex;
         uint96 tAmountToBurn = 0;
 
@@ -1248,7 +1248,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
             i++
         ) {
             address application = operatorStruct.authorizedApplications[i];
-            maxAuthorization = Math.max(
+            maxAuthorization = MathUpgradeable.max(
                 maxAuthorization,
                 operatorStruct.authorizations[application].authorized
             );
@@ -1258,19 +1258,19 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
             return 0;
         }
         if (stakeTypes != StakeType.T) {
-            maxAuthorization -= Math.min(
+            maxAuthorization -= MathUpgradeable.min(
                 maxAuthorization,
                 operatorStruct.tStake
             );
         }
         if (stakeTypes != StakeType.NU) {
-            maxAuthorization -= Math.min(
+            maxAuthorization -= MathUpgradeable.min(
                 maxAuthorization,
                 operatorStruct.nuInTStake
             );
         }
         if (stakeTypes != StakeType.KEEP) {
-            maxAuthorization -= Math.min(
+            maxAuthorization -= MathUpgradeable.min(
                 maxAuthorization,
                 operatorStruct.keepInTStake
             );
@@ -1342,7 +1342,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         uint256 queueLength = slashingQueue.length;
         for (uint256 i = 0; i < _operators.length; i++) {
             address operator = _operators[i];
-            uint256 amountToSlash = Math.min(
+            uint256 amountToSlash = MathUpgradeable.min(
                 operators[operator].authorizations[msg.sender].authorized,
                 amount
             );
@@ -1360,7 +1360,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         if (notifier != address(0)) {
             uint256 reward = ((slashingQueue.length - queueLength) *
                 notificationReward).percent(rewardMultiplier);
-            reward = Math.min(reward, notifiersTreasury);
+            reward = MathUpgradeable.min(reward, notifiersTreasury);
             emit NotifierRewarded(notifier, reward);
             if (reward != 0) {
                 notifiersTreasury -= reward;
@@ -1453,7 +1453,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
                 application == address(0) ||
                 authorizedApplication == application
             ) {
-                authorization.authorized -= Math
+                authorization.authorized -= MathUpgradeable
                     .min(fromAmount, slashedAmount)
                     .toUint96();
             } else if (fromAmount <= totalStake) {

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -81,12 +81,18 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     uint256 internal constant GAS_LIMIT_AUTHORIZATION_DECREASE = 250000;
     uint256 internal constant CONVERSION_DIVISOR = 10**(18 - 3);
 
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     T internal immutable token;
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IKeepTokenStaking internal immutable keepStakingContract;
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     KeepStake internal immutable keepStake;
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     INuCypherStakingEscrow internal immutable nucypherStakingContract;
 
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     uint256 internal immutable keepRatio;
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     uint256 internal immutable nucypherRatio;
 
     address public governance;
@@ -103,7 +109,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     address[] public applications;
 
     SlashingEvent[] public slashingQueue;
-    uint256 public slashingQueueIndex = 0;
+    uint256 public slashingQueueIndex;
 
     event OperatorStaked(
         StakeType indexed stakeType,
@@ -211,6 +217,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     /// @param _keepVendingMachine Address of Keep vending machine
     /// @param _nucypherVendingMachine Address of NuCypher vending machine
     /// @param _keepStake Address of Keep contract with grant owners
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
         T _token,
         IKeepTokenStaking _keepStakingContract,

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -1701,6 +1701,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         pure
         returns (uint256 amount, uint96 tRemainder)
     {
+        //slither-disable-next-line weak-prng
         tRemainder = (tAmount % ratio).toUint96();
         uint256 convertibleAmount = tAmount - tRemainder;
         amount = (convertibleAmount * CONVERSION_DIVISOR) / ratio;

--- a/contracts/test/TestGovernorTestSet.sol
+++ b/contracts/test/TestGovernorTestSet.sol
@@ -12,6 +12,15 @@ contract TestTokenholderGovernorStub {
     address public timelock = address(0x42);
 }
 
+contract TestTokenholderGovernorStubV2 {
+    string public name = "TokenholderGovernor";
+    address public timelock;
+
+    constructor(address _timelock) {
+        timelock = _timelock;
+    }
+}
+
 contract TestStakerGovernor is StakerGovernor {
     constructor(
         IVotesHistory tStaking,

--- a/contracts/test/UpgradesTestSet.sol
+++ b/contracts/test/UpgradesTestSet.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity 0.8.9;
+
+contract SimpleStorage {
+
+    uint public value;
+
+    constructor() {}
+
+    function initialize(uint _value) external {
+        value = _value;
+    }
+}

--- a/contracts/test/UpgradesTestSet.sol
+++ b/contracts/test/UpgradesTestSet.sol
@@ -3,12 +3,20 @@
 pragma solidity 0.8.9;
 
 contract SimpleStorage {
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    uint256 public immutable implementationVersion;
+    uint256 public storedValue;
 
-    uint public value;
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(uint256 _version) {
+        implementationVersion = _version;
+    }
 
-    constructor() {}
+    function initialize(uint256 _value) external {
+        storedValue = _value;
+    }
 
-    function initialize(uint _value) external {
-        value = _value;
+    function setValue(uint256 _value) external {
+        storedValue = _value;
     }
 }

--- a/contracts/utils/SafeT.sol
+++ b/contracts/utils/SafeT.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity 0.8.9;
+
+import "../token/T.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
+
+/// @notice A wrapper around OpenZeppelin's `SafeERC20Upgradeable` but for
+///         the T token. Motivation is to prevent upgradeable contracts using T
+///         from depending on the `Address` library, which can be problematic
+///         since it uses `delegatecall`, which is discouraged by OpenZeppelin.
+library SafeT {
+    function safeTransfer(
+        T token,
+        address to,
+        uint256 value
+    ) internal {
+        SafeERC20Upgradeable.safeTransfer(
+            IERC20Upgradeable(address(token)),
+            to,
+            value
+        );
+    }
+
+    function safeTransferFrom(
+        T token,
+        address from,
+        address to,
+        uint256 value
+    ) internal {
+        SafeERC20Upgradeable.safeTransferFrom(
+            IERC20Upgradeable(address(token)),
+            from,
+            to,
+            value
+        );
+    }
+}

--- a/contracts/utils/SafeTUpgradeable.sol
+++ b/contracts/utils/SafeTUpgradeable.sol
@@ -19,11 +19,16 @@ import "../token/T.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 
-/// @notice A wrapper around OpenZeppelin's `SafeERC20Upgradeable` but for
-///         the T token. Motivation is to prevent upgradeable contracts using T
-///         from depending on the `Address` library, which can be problematic
-///         since it uses `delegatecall`, which is discouraged by OpenZeppelin.
-library SafeT {
+/// @notice A wrapper around OpenZeppelin's `SafeERC20Upgradeable` but specific
+///         to the T token. Use this library in upgradeable contracts. If your
+///         contract is non-upgradeable, then the traditional `SafeERC20` works.
+///         The motivation is to prevent upgradeable contracts that use T from
+///         depending on the `Address` library, which can be problematic since
+///         it uses `delegatecall`, which is discouraged by OpenZeppelin for use
+///         in upgradeable contracts.
+/// @dev This implementation force-casts T to `IERC20Upgradeable` to make it
+///      work with `SafeERC20Upgradeable`.
+library SafeTUpgradeable {
     function safeTransfer(
         T token,
         address to,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,6 +7,8 @@ import "hardhat-gas-reporter"
 import "hardhat-deploy"
 import "@tenderly/hardhat-tenderly"
 
+require("hardhat-contract-sizer")
+
 const config: HardhatUserConfig = {
   solidity: {
     compilers: [

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,6 +8,7 @@ import "hardhat-deploy"
 import "@tenderly/hardhat-tenderly"
 
 require("hardhat-contract-sizer")
+require("@openzeppelin/hardhat-upgrades")
 
 const config: HardhatUserConfig = {
   solidity: {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ethereum-waffle": "^3.4.0",
     "ethers": "^5.4.1",
     "hardhat": "^2.6.8",
+    "hardhat-contract-sizer": "^2.1.1",
     "hardhat-deploy": "^0.9.4",
     "hardhat-gas-reporter": "^1.0.4",
     "hardhat-local-networks-config-plugin": "^0.0.6",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
     "@openzeppelin/contracts": "^4.4",
+    "@openzeppelin/contracts-upgradeable": "^4.4",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep#d6ec02e",
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
+    "@openzeppelin/hardhat-upgrades": "^1.12.0",
     "@tenderly/hardhat-tenderly": "^1.0.12",
     "@types/chai": "^4.2.22",
     "@types/mocha": "^9.0.0",

--- a/test/governance/ProxyAdminWithDeputy.test.js
+++ b/test/governance/ProxyAdminWithDeputy.test.js
@@ -7,15 +7,18 @@ describe("ProxyAdminWithDeputy", () => {
   let deployer
   let deputy
   let timelock
-  let other
+  let originalAdmin
+
+  let SimpleStorage
+  const initialState = 42
 
   beforeEach(async () => {
-    ;[deployer, deputy, timelock, other] = await ethers.getSigners()
-
-    const SimpleStorage = await ethers.getContractFactory("SimpleStorage")
-    const initializerArgs = [42]
+    ;[deployer, deputy, timelock] = await ethers.getSigners()
+    SimpleStorage = await ethers.getContractFactory("SimpleStorage")
+    const initializerArgs = [initialState] // stored value in proxy state
     storage = await upgrades.deployProxy(SimpleStorage, initializerArgs, {
       kind: "transparent",
+      constructorArgs: [1], // implementation version 1
     })
     await storage.deployed()
 
@@ -28,38 +31,133 @@ describe("ProxyAdminWithDeputy", () => {
     const ProxyAdminWithDeputy = await ethers.getContractFactory(
       "ProxyAdminWithDeputy"
     )
-    admin = await ProxyAdminWithDeputy.deploy(tGov.address, deputy.address)
-    await admin.deployed()
+    adminWithDeputy = await ProxyAdminWithDeputy.deploy(
+      tGov.address,
+      deputy.address
+    )
+    await adminWithDeputy.deployed()
   })
 
   describe("Plain Upgrades deployment - No ProxyAdminWithDeputy", () => {
+    let newImplementationAddress
+    let adminInstance
+
+    beforeEach(async () => {
+      newImplementationAddress = await upgrades.prepareUpgrade(
+        storage.address,
+        SimpleStorage,
+        {
+          constructorArgs: [2],
+        }
+      )
+      adminInstance = await upgrades.admin.getInstance()
+    })
+
     it("ProxyAdmin is the admin for the UpgradeableProxy", async () => {
       const adminInstance = await upgrades.admin.getInstance()
       const adminAddress = await adminInstance.getProxyAdmin(storage.address)
       expect(adminInstance.address).to.equal(adminAddress)
+    })
+
+    it("before upgrade, implementation version is 1", async () => {
+      expect(await storage.implementationVersion()).to.equal(1)
+    })
+
+    it("before upgrade, state is as expected", async () => {
+      expect(await storage.storedValue()).to.equal(initialState)
+    })
+
+    it("ProxyAdmin can upgrade, version is now 2 and state is correct", async () => {
+      await adminInstance
+        .connect(deployer)
+        .upgrade(storage.address, newImplementationAddress)
+      expect(await storage.storedValue()).to.equal(initialState)
+      expect(await storage.implementationVersion()).to.equal(2)
+    })
+
+    it("Deputy can't upgrade", async () => {
+      await expect(
+        adminInstance
+          .connect(deputy)
+          .upgrade(storage.address, newImplementationAddress)
+      ).to.be.revertedWith("Ownable: caller is not the owner")
     })
   })
 
   describe("Patched Upgrades deployment - Using our ProxyAdminWithDeputy", () => {
     beforeEach(async () => {
-      // Tell the TransparentUpgradeableProxy that its admin is the
-      // ProxyAdminWithDeputy
-      await upgrades.admin.changeProxyAdmin(storage.address, admin.address)
+      // Change admin of TransparentUpgradeableProxy to the
+      // ProxyAdminWithDeputy contract
+      await upgrades.admin.changeProxyAdmin(
+        storage.address,
+        adminWithDeputy.address
+      )
 
       // We patch the Network Manifest to use our ProxyAdminWithDeputy.
       // This will facilitate reuse of the Upgrade plugin with our proxy admin.
       const manifest = new Manifest(31337) // await Manifest.forNetwork(provider);
       manifestData = await manifest.read()
-      manifestData.admin.address = admin.address
+      originalAdmin = manifestData.admin.address
+      manifestData.admin.address = adminWithDeputy.address
       await manifest.lockedRun(async () => {
         await manifest.write(manifestData)
       })
     })
 
-    it("ProxyAdmin is the admin for the UpgradeableProxy", async () => {
+    afterEach(async () => {
+      // We restore the Network Manifest
+      const manifest = new Manifest(31337) // await Manifest.forNetwork(provider);
+      manifestData = await manifest.read()
+      manifestData.admin.address = originalAdmin
+      await manifest.lockedRun(async () => {
+        await manifest.write(manifestData)
+      })
+    })
+
+    it("ProxyAdminWithDeputy is the admin for the UpgradeableProxy", async () => {
       const adminInstance = await upgrades.admin.getInstance()
       const adminAddress = await adminInstance.getProxyAdmin(storage.address)
       expect(adminInstance.address).to.equal(adminAddress)
+    })
+
+    describe("Upgrades procedure with ProxyAdminWithDeputy", () => {
+      let newImplementationAddress
+
+      beforeEach(async () => {
+        newImplementationAddress = await upgrades.prepareUpgrade(
+          storage.address,
+          SimpleStorage,
+          {
+            constructorArgs: [2],
+          }
+        )
+      })
+
+      it("before upgrade, implementation version is 1", async () => {
+        expect(await storage.implementationVersion()).to.equal(1)
+      })
+
+      it("before upgrade, state is as expected", async () => {
+        expect(await storage.storedValue()).to.equal(initialState)
+      })
+
+      it("Deputy can upgrade, version is now 2 and state is correct", async () => {
+        const adminInstance = await upgrades.admin.getInstance()
+        await adminInstance
+          .connect(deputy)
+          .upgrade(storage.address, newImplementationAddress)
+        expect(await storage.storedValue()).to.equal(initialState)
+        expect(await storage.implementationVersion()).to.equal(2)
+      })
+
+      it("ProxyAdminWithDeputy's owner (the Timelock) can upgrade, version is now 2 and state is correct", async () => {
+        const adminInstance = await upgrades.admin.getInstance()
+        await adminInstance
+          .connect(timelock)
+          .upgrade(storage.address, newImplementationAddress)
+        expect(await storage.storedValue()).to.equal(42)
+        expect(await storage.implementationVersion()).to.equal(2)
+      })
     })
   })
 })

--- a/test/governance/ProxyAdminWithDeputy.test.js
+++ b/test/governance/ProxyAdminWithDeputy.test.js
@@ -53,7 +53,6 @@ describe("ProxyAdminWithDeputy", () => {
     })
 
     it("ProxyAdmin is the admin for the UpgradeableProxy", async () => {
-      const adminInstance = await upgrades.admin.getInstance()
       const adminAddress = await adminInstance.getProxyAdmin(storage.address)
       expect(adminInstance.address).to.equal(adminAddress)
     })

--- a/test/governance/ProxyAdminWithDeputy.test.js
+++ b/test/governance/ProxyAdminWithDeputy.test.js
@@ -1,0 +1,47 @@
+const { expect } = require("chai")
+
+const { upgrades } = require("hardhat")
+const { Manifest }  = require("@openzeppelin/upgrades-core")
+
+describe("ProxyAdminWithDeputy", () => {
+  let deployer
+  let deputy
+  let timelock
+  let other
+
+  beforeEach(async () => {
+    ;[deployer, deputy, timelock, other] = await ethers.getSigners()
+
+    const SimpleStorage = await ethers.getContractFactory(
+      "SimpleStorage"
+    )
+    const initializerArgs = [42]
+    storage = await upgrades.deployProxy(
+      SimpleStorage,
+      initializerArgs,
+      {kind: "transparent"}
+    )
+    await storage.deployed()
+
+    const GovernorStub = await ethers.getContractFactory(
+      "TestTokenholderGovernorStubV2"
+    )
+    tGov = await GovernorStub.deploy(timelock.address)
+    await tGov.deployed()
+
+    const ProxyAdminWithDeputy = await ethers.getContractFactory(
+      "ProxyAdminWithDeputy"
+    )
+    admin = await ProxyAdminWithDeputy.deploy(tGov.address, deputy.address)
+    await admin.deployed()
+  })
+
+  describe("Plain Upgrades deployment - No ProxyAdminWithDeputy", () => {
+    it("ProxyAdmin is the admin for the UpgradeableProxy", async () => {
+      const adminInstance = await upgrades.admin.getInstance();
+      const adminAddress = await adminInstance.getProxyAdmin(storage.address);
+      expect(adminInstance.address).to.equal(adminAddress);
+    })
+  })
+
+})

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -17,6 +17,10 @@ const ApplicationStatus = {
   PAUSED: 2,
   DISABLED: 3,
 }
+const { upgrades } = require("hardhat")
+
+// FIXME: Investigate why the upgrades plug-in thinks we're using delegatecalls
+upgrades.silenceWarnings();
 
 describe("TokenStaking", () => {
   let tToken
@@ -128,13 +132,21 @@ describe("TokenStaking", () => {
     await nucypherStakingMock.deployed()
 
     const TokenStaking = await ethers.getContractFactory("TokenStaking")
-    tokenStaking = await TokenStaking.deploy(
-      tToken.address,
-      keepStakingMock.address,
-      nucypherStakingMock.address,
-      keepVendingMachine.address,
-      nucypherVendingMachine.address,
-      keepStake.address
+    const tokenStakingInitializerArgs = []
+    tokenStaking = await upgrades.deployProxy(
+      TokenStaking,
+      tokenStakingInitializerArgs,
+      {
+        constructorArgs: [
+          tToken.address,
+          keepStakingMock.address,
+          nucypherStakingMock.address,
+          keepVendingMachine.address,
+          nucypherVendingMachine.address,
+          keepStake.address,
+        ],
+        unsafeAllow: ["delegatecall"],
+      }
     )
     await tokenStaking.deployed()
 

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -20,7 +20,7 @@ const ApplicationStatus = {
 const { upgrades } = require("hardhat")
 
 // FIXME: Investigate why the upgrades plug-in thinks we're using delegatecalls
-upgrades.silenceWarnings();
+upgrades.silenceWarnings()
 
 describe("TokenStaking", () => {
   let tToken

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -19,9 +19,6 @@ const ApplicationStatus = {
 }
 const { upgrades } = require("hardhat")
 
-// FIXME: Investigate why the upgrades plug-in thinks we're using delegatecalls
-upgrades.silenceWarnings()
-
 describe("TokenStaking", () => {
   let tToken
   let keepVendingMachine
@@ -145,7 +142,6 @@ describe("TokenStaking", () => {
           nucypherVendingMachine.address,
           keepStake.address,
         ],
-        unsafeAllow: ["delegatecall"],
       }
     )
     await tokenStaking.deployed()

--- a/test/system/init-contracts.js
+++ b/test/system/init-contracts.js
@@ -169,7 +169,6 @@ async function deployTokenStaking(
         nuCypherVendingMachine.address,
         keepStake.address,
       ],
-      unsafeAllow: ["delegatecall"],
     }
   )
 

--- a/test/system/init-contracts.js
+++ b/test/system/init-contracts.js
@@ -1,4 +1,4 @@
-const { helpers } = require("hardhat")
+const { helpers, upgrades } = require("hardhat")
 const { impersonateAccount } = helpers.account
 const { to1e18 } = helpers.number
 
@@ -156,13 +156,21 @@ async function deployTokenStaking(
   keepStake
 ) {
   const TokenStaking = await ethers.getContractFactory("TokenStaking")
-  const tokenStaking = await TokenStaking.deploy(
-    tToken.address,
-    keepTokenStaking.address,
-    nuCypherStakingEscrow.address,
-    keepVendingMachine.address,
-    nuCypherVendingMachine.address,
-    keepStake.address
+  const tokenStakingInitializerArgs = []
+  const tokenStaking = await upgrades.deployProxy(
+    TokenStaking,
+    tokenStakingInitializerArgs,
+    {
+      constructorArgs: [
+        tToken.address,
+        keepTokenStaking.address,
+        nuCypherStakingEscrow.address,
+        keepVendingMachine.address,
+        nuCypherVendingMachine.address,
+        keepStake.address,
+      ],
+      unsafeAllow: ["delegatecall"],
+    }
   )
 
   await tokenStaking.deployed()

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,6 +606,11 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
+"@openzeppelin/contracts-upgradeable@^4.4":
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.4.0.tgz#85161d87c840c5bce2b6ed0c727b407e774852ae"
+  integrity sha512-hIEyWJHu7bDTv6ckxOaV+K3+7mVzhjtyvp3QSaz56Rk5PscXtPAbkiNTb3yz6UJCWHPWpxVyULVgZ6RubuFEZg==
+
 "@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.4":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.0.tgz#4a1df71f736c31230bbbd634dfb006a756b51e6b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -126,7 +126,7 @@
     patch-package "^6.2.2"
     postinstall-postinstall "^2.1.0"
 
-"@ethereumjs/block@^3.4.0", "@ethereumjs/block@^3.5.0", "@ethereumjs/block@^3.6.0":
+"@ethereumjs/block@^3.5.0", "@ethereumjs/block@^3.6.0":
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/block/-/block-3.6.0.tgz#5cf89ea748607597a3f8b038abc986e4ac0b05db"
   integrity sha512-dqLo1LtsLG+Oelu5S5tWUDG0pah3QUwV5TJZy2cm19BXDr4ka/S9XBSgao0i09gTcuPlovlHgcs6d7EZ37urjQ==
@@ -136,7 +136,7 @@
     ethereumjs-util "^7.1.3"
     merkle-patricia-tree "^4.2.2"
 
-"@ethereumjs/blockchain@^5.4.0", "@ethereumjs/blockchain@^5.5.0":
+"@ethereumjs/blockchain@^5.5.0":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethereumjs/blockchain/-/blockchain-5.5.1.tgz#60f1f50592c06cc47e1704800b88b7d32f609742"
   integrity sha512-JS2jeKxl3tlaa5oXrZ8mGoVBCz6YqsGG350XVNtHAtNZXKk7pU3rH4xzF2ru42fksMMqzFLzKh9l4EQzmNWDqA==
@@ -150,7 +150,7 @@
     lru-cache "^5.1.1"
     semaphore-async-await "^1.5.1"
 
-"@ethereumjs/common@^2.4.0", "@ethereumjs/common@^2.6.0":
+"@ethereumjs/common@^2.6.0":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/common/-/common-2.6.0.tgz#feb96fb154da41ee2cc2c5df667621a440f36348"
   integrity sha512-Cq2qS0FTu6O2VU1sgg+WyU9Ps0M6j/BEMHN+hRaECXCV/r0aI78u4N6p52QW/BDVhwWZpCdrvG8X7NJdzlpNUA==
@@ -169,7 +169,7 @@
     ethereumjs-util "^7.1.1"
     miller-rabin "^4.0.0"
 
-"@ethereumjs/tx@^3.3.0", "@ethereumjs/tx@^3.4.0":
+"@ethereumjs/tx@^3.4.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.4.0.tgz#7eb1947eefa55eb9cf05b3ca116fb7a3dbd0bce7"
   integrity sha512-WWUwg1PdjHKZZxPPo274ZuPsJCWV3SqATrEKQP1n2DrVYVP1aZIYpo/mFaA0BDoE0tIQmBeimRCEA0Lgil+yYw==
@@ -177,7 +177,7 @@
     "@ethereumjs/common" "^2.6.0"
     ethereumjs-util "^7.1.3"
 
-"@ethereumjs/vm@^5.5.2":
+"@ethereumjs/vm@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethereumjs/vm/-/vm-5.6.0.tgz#e0ca62af07de820143674c30b776b86c1983a464"
   integrity sha512-J2m/OgjjiGdWF2P9bj/4LnZQ1zRoZhY8mRNVw/N3tXliGI8ai1sI1mlDPkLpeUUM4vq54gH6n0ZlSpz8U/qlYQ==
@@ -2021,9 +2021,9 @@ bignumber.js@^7.2.0:
   integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
 
 bignumber.js@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.1.tgz#8d7ba124c882bfd8e43260c67475518d0689e4e5"
-  integrity sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA==
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.0.2.tgz#71c6c6bed38de64e24a65ebe16cfcf23ae693673"
+  integrity sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -2093,7 +2093,7 @@ bn.js@^5.0.0, bn.js@^5.1.1, bn.js@^5.1.2, bn.js@^5.2.0:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
 
-body-parser@1.19.0, body-parser@^1.16.0:
+body-parser@1.19.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
@@ -2108,6 +2108,22 @@ body-parser@1.19.0, body-parser@^1.16.0:
     qs "6.7.0"
     raw-body "2.4.0"
     type-is "~1.6.17"
+
+body-parser@^1.16.0:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.1.tgz#1499abbaa9274af3ecc9f6f10396c995943e31d4"
+  integrity sha512-8ljfQi5eBk8EJfECMrgqNGWPEY5jWP+1IzkzkGdFFEwFQZZyaZ21UqdaHktgiMlH0xLHqIFtE/u2OYE5dOtViA==
+  dependencies:
+    bytes "3.1.1"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.8.1"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.9.6"
+    raw-body "2.4.2"
+    type-is "~1.6.18"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -2578,6 +2594,16 @@ cli-table3@^0.5.0:
   optionalDependencies:
     colors "^1.1.2"
 
+cli-table3@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.6.0.tgz#b7b1bc65ca8e7b5cef9124e13dc2b21e2ce4faee"
+  integrity sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==
+  dependencies:
+    object-assign "^4.1.0"
+    string-width "^4.2.0"
+  optionalDependencies:
+    colors "^1.1.2"
+
 cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
@@ -2650,7 +2676,7 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-colors@^1.1.2:
+colors@^1.1.2, colors@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -3213,9 +3239,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.47:
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.14.tgz#b0aa41fbfbf2eff8c2c6f7a871c03075250f8956"
-  integrity sha512-RsGkAN9JEAYMObS72kzUsPPcPGMqX1rBqGuXi9aa4TBKLzICoLf+DAAtd0fVFzrniJqYzpby47gthCUoObfs0Q==
+  version "1.4.16"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.16.tgz#38ddecc616385e6f101359d1b978c802664157d2"
+  integrity sha512-BQb7FgYwnu6haWLU63/CdVW+9xhmHls3RCQUFiV4lvw3wimEHTVcUk2hkuZo76QhR8nnDdfZE7evJIZqijwPdA==
 
 elliptic@6.3.3:
   version "6.3.3"
@@ -4910,6 +4936,14 @@ har-validator@~5.1.3:
     ajv "^6.12.3"
     har-schema "^2.0.0"
 
+hardhat-contract-sizer@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/hardhat-contract-sizer/-/hardhat-contract-sizer-2.1.1.tgz#d861bfac8dff00cca859e14c5a4843367dd0f068"
+  integrity sha512-QgfuwdUkKT7Ugn6Zja26Eie7h6OLcBfWBewaaQtYMCzyglNafQPgUIznN2C42/iFmGrlqFPbqv4B98Iev89KSQ==
+  dependencies:
+    cli-table3 "^0.6.0"
+    colors "^1.4.0"
+
 hardhat-deploy@^0.9.4:
   version "0.9.14"
   resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.9.14.tgz#88c07497efd14cfca6f9fed1574f0bad65f0a8a0"
@@ -4955,15 +4989,15 @@ hardhat-local-networks-config-plugin@^0.0.6:
     deepmerge "^4.2.2"
 
 hardhat@^2.6.8:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.7.0.tgz#d8f01bc07bdd88ccaa00719ddb18618bc59a73b5"
-  integrity sha512-DqweY3KH5gwExoZ8EtsAfioj0Hk0NBXWXT3fMXWkiQNfyYBoZLrqdPNkbJ/E2LD4mZ+BKF7v/1chYR9ZCn2Z+g==
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/hardhat/-/hardhat-2.7.1.tgz#576a0420ce874fe00e7749924aefef2a0b14d3ae"
+  integrity sha512-zmyQe9tOMI9UmFXNnDzdrKMezmKyAawVxU0oIipWPbl9D3zvQJEKaOaNgc9gG31dgkh4WqWCnUR/QxV1U6ctzA==
   dependencies:
-    "@ethereumjs/block" "^3.4.0"
-    "@ethereumjs/blockchain" "^5.4.0"
-    "@ethereumjs/common" "^2.4.0"
-    "@ethereumjs/tx" "^3.3.0"
-    "@ethereumjs/vm" "^5.5.2"
+    "@ethereumjs/block" "^3.6.0"
+    "@ethereumjs/blockchain" "^5.5.0"
+    "@ethereumjs/common" "^2.6.0"
+    "@ethereumjs/tx" "^3.4.0"
+    "@ethereumjs/vm" "^5.6.0"
     "@ethersproject/abi" "^5.1.2"
     "@sentry/node" "^5.18.1"
     "@solidity-parser/parser" "^0.14.0"
@@ -4981,7 +5015,7 @@ hardhat@^2.6.8:
     eth-sig-util "^2.5.2"
     ethereum-cryptography "^0.1.2"
     ethereumjs-abi "^0.6.8"
-    ethereumjs-util "^7.1.0"
+    ethereumjs-util "^7.1.3"
     find-up "^2.1.0"
     fp-ts "1.19.3"
     fs-extra "^7.0.1"
@@ -5561,9 +5595,9 @@ is-natural-number@^4.0.1:
   integrity sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=
 
 is-negative-zero@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
-  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
+  integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
 
 is-number-object@^1.0.4:
   version "1.0.6"
@@ -5654,11 +5688,11 @@ is-utf8@^0.2.0:
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
 is-weakref@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.1.tgz#842dba4ec17fa9ac9850df2d6efbc1737274f2a2"
-  integrity sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
+  integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
   dependencies:
-    call-bind "^1.0.0"
+    call-bind "^1.0.2"
 
 is-windows@^1.0.2:
   version "1.0.2"
@@ -7493,6 +7527,11 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@6.9.6:
+  version "6.9.6"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
+  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
+
 qs@^6.4.0, qs@^6.7.0, qs@^6.9.4:
   version "6.10.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.2.tgz#c1431bea37fc5b24c5bdbafa20f16bdf2a4b9ffe"
@@ -7549,7 +7588,7 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-body@^2.4.1:
+raw-body@2.4.2, raw-body@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.2.tgz#baf3e9c21eebced59dd6533ac872b71f7b61cb32"
   integrity sha512-RPMAFUJP19WIet/99ngh6Iv8fzAbqum4Li7AD6DtGaW2RpMB/11xDoalPiJMTbu6I3hkbMVkATvZrqb9EEqeeQ==
@@ -8511,7 +8550,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^4.2.3:
+string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9079,9 +9118,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^4.4.4:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
-  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.3.tgz#afaa858e68c7103317d89eb90c5d8906268d353c"
+  integrity sha512-eVYaEHALSt+s9LbvgEv4Ef+Tdq7hBiIZgii12xXJnukryt3pMgJf6aKhoCZ3FWQsu6sydEnkg11fYXLzhLBjeQ==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -616,6 +616,27 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.4.0.tgz#4a1df71f736c31230bbbd634dfb006a756b51e6b"
   integrity sha512-dlKiZmDvJnGRLHojrDoFZJmsQVeltVeoiRN7RK+cf2FmkhASDEblE0RiaYdxPNsUZa6mRG8393b9bfyp+V5IAw==
 
+"@openzeppelin/hardhat-upgrades@^1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-1.12.0.tgz#35b4dd9bdefb203e7e0ba4b1c38df133bf721ddf"
+  integrity sha512-C5eOSt01zHKYUaRRDunqCsP5fXLpqFatIEs+NywVKLfVV6LNatugaNiRC4oHT8FF8wnr38uSoWrJJVTRoXUECw==
+  dependencies:
+    "@openzeppelin/upgrades-core" "^1.10.0"
+
+"@openzeppelin/upgrades-core@^1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/upgrades-core/-/upgrades-core-1.10.0.tgz#d3aa72b7a23827e0e6daff08ddfb8dcd75171abb"
+  integrity sha512-N20t1i1wlHrVmu3etVZLiaRxT6XLkCrO9gIo4mUZNpsaVftl8V+WBu8o940AjoYXvzTEqj7O0re2DSFzjpkRBw==
+  dependencies:
+    bn.js "^5.1.2"
+    cbor "^8.0.0"
+    chalk "^4.1.0"
+    compare-versions "^3.6.0"
+    debug "^4.1.1"
+    ethereumjs-util "^7.0.3"
+    proper-lockfile "^4.1.1"
+    solidity-ast "^0.4.15"
+
 "@openzeppelin/upgrades@^2.7.2":
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/upgrades/-/upgrades-2.8.0.tgz#8086ab9c99d9f8dac7205030b0f9e7e4a280c4a3"
@@ -2390,6 +2411,13 @@ cbor@^4.1.5:
     json-text-sequence "^0.1"
     nofilter "^1.0.3"
 
+cbor@^8.0.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
+  dependencies:
+    nofilter "^3.1.0"
+
 chai@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.4.tgz#b55e655b31e1eac7099be4c08c21964fce2e6c49"
@@ -2422,7 +2450,7 @@ chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.1.2:
+chalk@^4.0.0, chalk@^4.1.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2662,6 +2690,11 @@ commander@^2.8.1:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
+compare-versions@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.6.0.tgz#1a5689913685e5a87637b8d3ffca75514ec41d62"
+  integrity sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
 
 component-emitter@^1.2.1:
   version "1.3.0"
@@ -3957,7 +3990,7 @@ ethereumjs-util@^5.0.0, ethereumjs-util@^5.0.1, ethereumjs-util@^5.1.1, ethereum
     rlp "^2.0.0"
     safe-buffer "^5.1.1"
 
-ethereumjs-util@^7.0.2, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.1, ethereumjs-util@^7.1.2, ethereumjs-util@^7.1.3:
+ethereumjs-util@^7.0.2, ethereumjs-util@^7.0.3, ethereumjs-util@^7.1.0, ethereumjs-util@^7.1.1, ethereumjs-util@^7.1.2, ethereumjs-util@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.1.3.tgz#b55d7b64dde3e3e45749e4c41288238edec32d23"
   integrity sha512-y+82tEbyASO0K0X1/SRhbJJoAlfcvq8JbrG4a5cjrOks7HS/36efU/0j2flxCPOUM++HFahk33kr/ZxyC4vNuw==
@@ -4854,7 +4887,7 @@ got@^7.1.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0:
+graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.8"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
@@ -6753,6 +6786,11 @@ nofilter@^1.0.3:
   resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
   integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
 
+nofilter@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
+  integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
+
 normalize-package-data@^2.3.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -7335,6 +7373,15 @@ promise@^8.0.0:
   dependencies:
     asap "~2.0.6"
 
+proper-lockfile@^4.1.1:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 proxy-addr@~2.0.5:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.7.tgz#f19fe69ceab311eeb94b42e70e8c2070f9ba1025"
@@ -7814,6 +7861,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+retry@^0.12.0:
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.12.0.tgz#1b42a6266a21f07421d1b0b54b7dc167b01c013b"
+  integrity sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=
+
 rimraf@2.6.3:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
@@ -8273,6 +8325,11 @@ solhint@^3.3.6:
     semver "^6.3.0"
   optionalDependencies:
     prettier "^1.14.3"
+
+solidity-ast@^0.4.15:
+  version "0.4.28"
+  resolved "https://registry.yarnpkg.com/solidity-ast/-/solidity-ast-0.4.28.tgz#5589998512b9a3602e6ba612cbe7fed7401294f4"
+  integrity sha512-RtZCP5tSvZMadVtg9/IfLmAMKDOnQEvG2HA6VnPuoTMxqxsbbn4lQy8jgH3RVbqW0eO1hd7cSCKecb72/OeOIw==
 
 solidity-comments-extractor@^0.0.7:
   version "0.0.7"


### PR DESCRIPTION
This PR adds the logic necessary to implement upgradeability for `TokenStaking`, using [OpenZeppelin's Upgradeability framework](https://docs.openzeppelin.com/openzeppelin/upgrades). In particular, we use the [`TransparentUpgradeableProxy` approach](https://docs.openzeppelin.com/contracts/4.x/api/proxy#TransparentUpgradeableProxy) for `TokenStaking`; one of the consequences of the use of these types of proxies is the recommendation to use a dedicated `ProxyAdmin` contract to manage upgrades. This is natively handled by OpenZeppelin's `upgrades` plugin for `hardhat`, which we also include in this project.

We did, however, required a customization over the off-the-shelf upgradeability solution from OpenZeppelin: our DAO adds  the figure of the Emergency Security Developer Multisig (ESDM) as a secondary upgrade track (where the primary upgrade track is the Staker DAO's Timelock contract). To support this, this PR introduces a variant of the `ProxyAdmin` contract, called `ProxyAdminWithDeputy`, which simply adds the possibility for a "deputy" to perform upgrades.

This PR also tries to reduce as much as possible the size of TokenStaking, since naively adding the upgradeable base contracts puts it over the size limit. In particular, this PR simplifies some logic, such as the NU/KEEP to T conversion functions and removes the `Ownable` base contract from `TokenStaking`, in favor of an ad-hoc, simpler solution.
