### PR TITLE
Change semver range for `keep-core` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@keep-network/keep-core": ">1.8.0-dev <1.8.0-ropsten",
+    "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
     "@openzeppelin/contracts": "^4.4",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
   },
   "peerDependencies": {
-    "@keep-network/keep-core": ">1.8.0-dev <1.8.0-ropsten"
+    "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,7 +577,7 @@
     deepmerge "^4.2.2"
     untildify "^4.0.0"
 
-"@keep-network/keep-core@>1.8.0-dev <1.8.0-ropsten":
+"@keep-network/keep-core@>1.8.0-dev <1.8.0-pre":
   version "1.8.0-dev.5"
   resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.0-dev.5.tgz#8b4d08ec437f29c94723ee54fcf76456ba5408c3"
   integrity sha512-QVkpO5X28Vczj/xHezV0z2UuMw8QFaR3C8x/d6+3adedsL3nCxgveIGTUcXSuYpBqfx0v4/xT+9bIK7BwLkGPw==


### PR DESCRIPTION
We want to have a dependency here to the `keep-core` packages versioned
`1.8.0-dev.X`. In npm repository we have both `1.8.0-dev.X` and
`1.8.0-pre.X` packages present, so we need to exclude `1.8.0-pre.X`
packages from the semver range if we don't want tu use them.