### PR TITLE
Add hardhat support for rinkeby testnet 

### DIFF
--- a/.hardhat/networks_TEMPLATE.ts
+++ b/.hardhat/networks_TEMPLATE.ts
@@ -11,19 +11,16 @@ const config: LocalNetworksConfig = {
       url: "url not set",
       from: "address not set",
       accounts: ["private key not set"],
-      tags: ["tenderly"],
     },
     ropsten: {
       url: "url not set",
       from: "address not set",
       accounts: ["private key not set"],
-      tags: ["tenderly"],
     },
     mainnet: {
       url: "url not set",
       from: "address not set",
       accounts: ["private key not set"],
-      tags: ["tenderly"],
     },
   },
 }

--- a/.hardhat/networks_TEMPLATE.ts
+++ b/.hardhat/networks_TEMPLATE.ts
@@ -7,6 +7,12 @@ import { LocalNetworksConfig } from "@keep-network/hardhat-local-networks-config
 
 const config: LocalNetworksConfig = {
   networks: {
+    rinkeby: {
+      url: "url not set",
+      from: "address not set",
+      accounts: ["private key not set"],
+      tags: ["tenderly"],
+    },
     ropsten: {
       url: "url not set",
       from: "address not set",

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -46,6 +46,14 @@ const config: HardhatUserConfig = {
       chainId: 1101,
       tags: ["local"],
     },
+    rinkeby: {
+      url: process.env.CHAIN_API_URL || "",
+      chainId: 4,
+      accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
+        ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
+        : undefined,
+      tags: ["tenderly"],
+    },
     ropsten: {
       url: process.env.CHAIN_API_URL || "",
       chainId: 3,


### PR DESCRIPTION
We're adding support for rinkeby testnet. To deploy contracts locally
on rinkeby one can:
* use standard `hardhat.config.ts` config (`CHAIN_API_URL` and
  `CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY` environment variables would need
  to be set locally)
  
OR
* use custom configuration file with the config for the `rinkeby`
  testnet and link that file in the `hardhat.config.ts` like this:
  ```
  module.exports = {
  localNetworksConfig: '~/.hardhat/networks.ts'
  }
  ```
  In case a `localNetworksConfig` is not provided, the plugin will try
  to read it from `~/.hardhat/networks.json`.
  The `./.hardhat/networks_TEMPLATE.ts` contains a template for the
  file overwriting the standard config. Setting chain api url in `url`
  and private key in `accounts` should be enough to get the deployment
  working.