### PR TITLE
Renamed ProviderStaked event to Staked

### DIFF
--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -115,7 +115,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     SlashingEvent[] public slashingQueue;
     uint256 public slashingQueueIndex;
 
-    event ProviderStaked(
+    event Staked(
         StakeType indexed stakeType,
         address indexed owner,
         address indexed stakingProvider,
@@ -295,7 +295,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
 
         increaseStakeCheckpoint(stakingProvider, amount);
 
-        emit ProviderStaked(
+        emit Staked(
             StakeType.T,
             msg.sender,
             stakingProvider,
@@ -337,7 +337,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
 
         increaseStakeCheckpoint(stakingProvider, tAmount);
 
-        emit ProviderStaked(
+        emit Staked(
             StakeType.KEEP,
             stakingProviderStruct.owner,
             stakingProvider,
@@ -385,7 +385,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
 
         increaseStakeCheckpoint(stakingProvider, tAmount);
 
-        emit ProviderStaked(
+        emit Staked(
             StakeType.NU,
             msg.sender,
             stakingProvider,

--- a/docs/rfc-1-staking-contract.adoc
+++ b/docs/rfc-1-staking-contract.adoc
@@ -439,7 +439,7 @@ staking provider.
 Sets cached legacy stake amount to 0, sets the liquid T stake amount to 0 and
 withdraws all liquid T from the stake to the owner. Reverts if there is at least one
 non-zero authorization. Can be called only by the delegation owner or the
-staking  provider.
+staking provider.
 
 === Keeping information in sync
 

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -385,9 +385,9 @@ describe("TokenStaking", () => {
           ).to.equal(amount)
         })
 
-        it("should emit ProviderStaked event", async () => {
+        it("should emit Staked event", async () => {
           await expect(tx)
-            .to.emit(tokenStaking, "ProviderStaked")
+            .to.emit(tokenStaking, "Staked")
             .withArgs(
               StakeTypes.T,
               staker.address,
@@ -583,9 +583,9 @@ describe("TokenStaking", () => {
           ).to.equal(0)
         })
 
-        it("should emit ProviderStaked event", async () => {
+        it("should emit Staked event", async () => {
           await expect(tx)
-            .to.emit(tokenStaking, "ProviderStaked")
+            .to.emit(tokenStaking, "Staked")
             .withArgs(
               StakeTypes.KEEP,
               staker.address,
@@ -801,9 +801,9 @@ describe("TokenStaking", () => {
         ).to.equal(tAmount)
       })
 
-      it("should emit ProviderStaked event", async () => {
+      it("should emit Staked event", async () => {
         await expect(tx)
-          .to.emit(tokenStaking, "ProviderStaked")
+          .to.emit(tokenStaking, "Staked")
           .withArgs(
             StakeTypes.NU,
             staker.address,


### PR DESCRIPTION
~~Depends on #71~~

~~Leaving as a draft until #71 is merged.~~

It is not the staking provider who is staking in the staking contract.

The token owner is staking into the staking contract appointing the
staking provider as the one who will operate in the network on the
token owner's behalf.