### PR TITLE
Incorporate workflow in the CI flow

### DIFF
--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -148,6 +148,18 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }}
 
+      - name: Notify CI about completion of the workflow
+        uses: keep-network/ci/actions/notify-workflow-completed@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          module: "github.com/threshold-network/solidity-contracts"
+          url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          environment: ${{ github.event.inputs.environment }}
+          upstream_builds: ${{ github.event.inputs.upstream_builds }}
+          upstream_ref: ${{ github.event.inputs.upstream_ref }}
+          version: ${{ steps.npm-version-bump.outputs.version }}
+
       - name: Upload files needed for etherscan verification
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
We're adding `Solidity` workflow to he CI flow. After npm package gets
published, `ci` projects will be informed about execution of the
workflow and will start execution of the modules which are configured as
direct downstream modules in `keep-network/ci/config/config.json/`.
Changes required on the `ci` repo side to make that work will be
delivered in a separate PR/commit.

Ref:
https://github.com/keep-network/ci/pull/24 (we should merge that one before #76)