### PR TITLE
Remove artifacts created during install before etherscan-verify

### DIFF
--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -181,6 +181,7 @@ jobs:
       - name: Prepare for verification on Etherscan
         run: |
           rm -rf ./node_modules/@keep-network/keep-core
+          rm -rf ./external/npm
 
       - name: Verify contracts on Etherscan
         env:


### PR DESCRIPTION
Some time ago a postinstall script was added to the `package.json` as a
workaround for a problem with hardhat not handling situation when two
different contracts with the same name are processed. As a by-product of
this workaround, during yarn install
a `external/npm/@keep-network/keep-core/artifacts` directory is created,
which contains `keep-core` contracts. We don't want to verify those
contracts during execution of `contracts-etherscan-verification` job. To
exclude them, we need to remove those files before `hardhat
etherscan-verify` command is run. The `./external/mainnet` folder
contains files which do not break etherscan verification, so we're
limiting removal of files to `./external/npm` path.