### PR TITLE
Configure `KeepRegistry`

### DIFF
--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -133,6 +133,7 @@ jobs:
         env:
           CHAIN_API_URL: ${{ secrets.ROPSTEN_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.ROPSTEN_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.ROPSTEN_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version

--- a/contracts/test/KeepRegistryStub.sol
+++ b/contracts/test/KeepRegistryStub.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+pragma solidity 0.8.9;
+
+import "./IKeepRegistry.sol";
+
+contract KeepRegistryStub is IKeepRegistry {
+    event OperatorContractApproved(address operatorContract);
+
+    address public registryKeeper;
+
+    constructor() public {
+        registryKeeper = msg.sender;
+    }
+
+    function approveOperatorContract(address operatorContract) external {
+        emit OperatorContractApproved(operatorContract);
+    }
+}

--- a/contracts/test/KeepRegistryStub.sol
+++ b/contracts/test/KeepRegistryStub.sol
@@ -5,9 +5,9 @@ pragma solidity 0.8.9;
 import "./IKeepRegistry.sol";
 
 contract KeepRegistryStub is IKeepRegistry {
-    event OperatorContractApproved(address operatorContract);
-
     address public registryKeeper;
+
+    event OperatorContractApproved(address operatorContract);
 
     constructor() public {
         registryKeeper = msg.sender;

--- a/deploy/00_resolve_keep_registry.ts
+++ b/deploy/00_resolve_keep_registry.ts
@@ -1,0 +1,31 @@
+import { HardhatRuntimeEnvironment, HardhatNetworkConfig } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, deployments, helpers } = hre
+  const { log } = deployments
+  const { keepDeployer } = await getNamedAccounts()
+
+  const KeepRegistry = await deployments.getOrNull("KeepRegistry")
+
+  if (KeepRegistry && helpers.address.isValid(KeepRegistry.address)) {
+    log(`using existing KeepRegistry contract at ${KeepRegistry.address}`)
+  } else if (
+    hre.network.name !== "hardhat" ||
+    (hre.network.config as HardhatNetworkConfig).forking.enabled
+  ) {
+    throw new Error("deployed KeepRegistry contract not found")
+  } else {
+    log(`deploying KeepRegistry stub`)
+
+    await deployments.deploy("KeepRegistry", {
+      contract: "KeepRegistryStub",
+      from: keepDeployer,
+      log: true,
+    })
+  }
+}
+
+export default func
+
+func.tags = ["KeepRegistry"]

--- a/deploy/08_configure_keep_registry.ts
+++ b/deploy/08_configure_keep_registry.ts
@@ -24,3 +24,6 @@ export default func
 
 func.tags = ["ConfigureKeepRegistry"]
 func.dependencies = ["TokenStaking", "KeepRegistry"]
+func.skip = async function (hre: HardhatRuntimeEnvironment): Promise<boolean> {
+  return hre.network.name === "mainnet"
+}

--- a/deploy/08_configure_keep_registry.ts
+++ b/deploy/08_configure_keep_registry.ts
@@ -1,0 +1,28 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, deployments } = hre
+  const { deployer } = await getNamedAccounts()
+  const { execute, log } = deployments
+
+  const TokenStaking = await deployments.get("TokenStaking")
+
+  await execute(
+    "KeepRegistry",
+    // TODO: We should execute this transaction from Keep deployer account. The
+    // Keep deployer account and T deployer account are 2 different accounts.
+    { from: deployer },
+    "approveOperatorContract",
+    TokenStaking.address
+  )
+
+  log(
+    `Approved T TokenStaking operator contract [${TokenStaking.address}] in Keep registry`
+  )
+}
+
+export default func
+
+func.tags = ["ConfigureKeepRegistry"]
+func.dependencies = ["TokenStaking", "KeepRegistry"]

--- a/deploy/08_configure_keep_registry.ts
+++ b/deploy/08_configure_keep_registry.ts
@@ -3,16 +3,14 @@ import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments } = hre
-  const { deployer } = await getNamedAccounts()
+  const { keepDeployer } = await getNamedAccounts()
   const { execute, log } = deployments
 
   const TokenStaking = await deployments.get("TokenStaking")
 
   await execute(
     "KeepRegistry",
-    // TODO: We should execute this transaction from Keep deployer account. The
-    // Keep deployer account and T deployer account are 2 different accounts.
-    { from: deployer },
+    { from: keepDeployer },
     "approveOperatorContract",
     TokenStaking.address
   )

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -58,7 +58,10 @@ const config: HardhatUserConfig = {
       url: process.env.CHAIN_API_URL || "",
       chainId: 3,
       accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
-        ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
+        ? [
+            process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY,
+            process.env.KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY,
+          ]
         : undefined,
       tags: ["tenderly"],
     },
@@ -101,6 +104,10 @@ const config: HardhatUserConfig = {
     },
     thresholdCouncil: {
       mainnet: "0x00", // FIXME: Provide value
+    },
+    keepDeployer: {
+      default: 0,
+      ropsten: "0x923C5Dbf353e99394A21Aa7B67F3327Ca111C67D",
     },
   },
   mocha: {


### PR DESCRIPTION
Add the new deployment script that approves the `TTokenStaking` contract
in `KeepRegistry`. Each operator contract must be approved before it can
be authorized by a staker or used by a service contract.