### PR TITLE
Preparation for deployment of TokenStaking

### DIFF
--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -1,0 +1,305 @@
+{
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x758279CE7f54568A149bcdFcc7699e20b1dE43E5",
+    "txHash": "0xed01f878c6c5a160dd137fe0dce837e2c745415784125380919232b715db665a",
+    "deployTransaction": {
+      "hash": "0xed01f878c6c5a160dd137fe0dce837e2c745415784125380919232b715db665a",
+      "type": 2,
+      "accessList": [],
+      "blockHash": null,
+      "blockNumber": null,
+      "transactionIndex": null,
+      "confirmations": 0,
+      "from": "0xFfFd7092685bDeeBD121D1A0FEA3c349114Cce50",
+      "gasPrice": {
+        "type": "BigNumber",
+        "hex": "0x134549158c"
+      },
+      "maxPriorityFeePerGas": {
+        "type": "BigNumber",
+        "hex": "0x77359400"
+      },
+      "maxFeePerGas": {
+        "type": "BigNumber",
+        "hex": "0x134549158c"
+      },
+      "gasLimit": {
+        "type": "BigNumber",
+        "hex": "0x0762b4"
+      },
+      "to": null,
+      "value": {
+        "type": "BigNumber",
+        "hex": "0x00"
+      },
+      "nonce": 2,
+      "data": "0x608060405234801561001057600080fd5b50600080546001600160a01b031916339081178255604051909182917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908290a350610759806100616000396000f3fe60806040526004361061007b5760003560e01c80639623609d1161004e5780639623609d1461011157806399a88ec414610124578063f2fde38b14610144578063f3b7dead146101645761007b565b8063204e1c7a14610080578063715018a6146100bc5780637eff275e146100d35780638da5cb5b146100f3575b600080fd5b34801561008c57600080fd5b506100a061009b366004610515565b610184565b6040516001600160a01b03909116815260200160405180910390f35b3480156100c857600080fd5b506100d1610215565b005b3480156100df57600080fd5b506100d16100ee366004610554565b610292565b3480156100ff57600080fd5b506000546001600160a01b03166100a0565b6100d161011f36600461058c565b61031c565b34801561013057600080fd5b506100d161013f366004610554565b6103ad565b34801561015057600080fd5b506100d161015f366004610515565b610405565b34801561017057600080fd5b506100a061017f366004610515565b6104ef565b6000806000836001600160a01b03166040516101aa90635c60da1b60e01b815260040190565b600060405180830381855afa9150503d80600081146101e5576040519150601f19603f3d011682016040523d82523d6000602084013e6101ea565b606091505b5091509150816101f957600080fd5b8080602001905181019061020d9190610538565b949350505050565b6000546001600160a01b031633146102485760405162461bcd60e51b815260040161023f906106c0565b60405180910390fd5b600080546040516001600160a01b03909116907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908390a3600080546001600160a01b0319169055565b6000546001600160a01b031633146102bc5760405162461bcd60e51b815260040161023f906106c0565b6040516308f2839760e41b81526001600160a01b038281166004830152831690638f283970906024015b600060405180830381600087803b15801561030057600080fd5b505af1158015610314573d6000803e3d6000fd5b505050505050565b6000546001600160a01b031633146103465760405162461bcd60e51b815260040161023f906106c0565b60405163278f794360e11b81526001600160a01b03841690634f1ef286903490610376908690869060040161065d565b6000604051808303818588803b15801561038f57600080fd5b505af11580156103a3573d6000803e3d6000fd5b5050505050505050565b6000546001600160a01b031633146103d75760405162461bcd60e51b815260040161023f906106c0565b604051631b2ce7f360e11b81526001600160a01b038281166004830152831690633659cfe6906024016102e6565b6000546001600160a01b0316331461042f5760405162461bcd60e51b815260040161023f906106c0565b6001600160a01b0381166104945760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b606482015260840161023f565b600080546040516001600160a01b03808516939216917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e091a3600080546001600160a01b0319166001600160a01b0392909216919091179055565b6000806000836001600160a01b03166040516101aa906303e1469160e61b815260040190565b600060208284031215610526578081fd5b81356105318161070b565b9392505050565b600060208284031215610549578081fd5b81516105318161070b565b60008060408385031215610566578081fd5b82356105718161070b565b915060208301356105818161070b565b809150509250929050565b6000806000606084860312156105a0578081fd5b83356105ab8161070b565b925060208401356105bb8161070b565b9150604084013567ffffffffffffffff808211156105d7578283fd5b818601915086601f8301126105ea578283fd5b8135818111156105fc576105fc6106f5565b604051601f8201601f19908116603f01168101908382118183101715610624576106246106f5565b8160405282815289602084870101111561063c578586fd5b82602086016020830137856020848301015280955050505050509250925092565b600060018060a01b038416825260206040818401528351806040850152825b818110156106985785810183015185820160600152820161067c565b818111156106a95783606083870101525b50601f01601f191692909201606001949350505050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b634e487b7160e01b600052604160045260246000fd5b6001600160a01b038116811461072057600080fd5b5056fea2646970667358221220d849f96f3086b9f82cdcf665adb8c697ace05638da1c7c16ab2d26293717af6764736f6c63430008020033",
+      "r": "0x6885b321b1e7c4aa593439aa23463195169cce9b91cd86ec64effcd72bc3e49a",
+      "s": "0x093ef2962156e17cf290ab77a5ae1cd524741b3cb96e56696984b5a4dc7e6ae4",
+      "v": 0,
+      "creates": "0x758279CE7f54568A149bcdFcc7699e20b1dE43E5",
+      "chainId": 1
+    }
+  },
+  "proxies": [
+    {
+      "address": "0x01B67b1194C75264d06F808A921228a95C765dd7",
+      "txHash": "0x72c9e245d04959716f24aea93308747960ba716f24a88846a5b2437b1146016c",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "1376613d6640bc8084fa4ed096e7e4fbfb8daf8435182b9ba1ec5d15ed38ada2": {
+      "address": "0xf6c54455f01e03F8Ff992E2a6AAae5349898259e",
+      "txHash": "0x45feca0e2b317b769aca4f0cbad05a1c33753cba5594ceb001e48954a608dc3f",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:115"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:117"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:119"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:120"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:122"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12396_storage)",
+            "src": "contracts/staking/TokenStaking.sol:126"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12407_storage)",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:129"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "slashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12414_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:131"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "slashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:132"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12396_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12396_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12401_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12401_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12401_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12407_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12407_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12373"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12373": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": ["NOT_APPROVED", "APPROVED", "PAUSED", "DISABLED"]
+          },
+          "t_array(t_struct(SlashingEvent)12414_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12414_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              },
+              {
+                "label": "application",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        }
+      }
+    }
+  }
+}

--- a/deploy/07_deploy_token_staking.ts
+++ b/deploy/07_deploy_token_staking.ts
@@ -1,8 +1,11 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
+import { ethers, upgrades } from "hardhat"
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments } = hre
+  const { execute, log } = deployments
   const { deployer } = await getNamedAccounts()
 
   const T = await deployments.get("T")
@@ -12,23 +15,65 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const VendingMachineNuCypher = await deployments.get("VendingMachineNuCypher")
   const KeepStake = await deployments.get("KeepStake")
 
-  const TokenStaking = await deployments.deploy("TokenStaking", {
-    from: deployer,
-    args: [
-      T.address,
-      KeepTokenStaking.address,
-      NuCypherStakingEscrow.address,
-      VendingMachineKeep.address,
-      VendingMachineNuCypher.address,
-      KeepStake.address,
-    ],
-    log: true,
-  })
+  const tokenStakingConstructorArgs = [
+    T.address,
+    KeepTokenStaking.address,
+    NuCypherStakingEscrow.address,
+    VendingMachineKeep.address,
+    VendingMachineNuCypher.address,
+    KeepStake.address,
+  ]
+  const tokenStakingInitializerArgs = []
+
+  let tokenStakingAddress
+  if (hre.network.name == "mainnet") {
+    const TokenStaking = await ethers.getContractFactory("TokenStaking")
+
+    const tokenStaking = await upgrades.deployProxy(
+      TokenStaking,
+      tokenStakingInitializerArgs,
+      {
+        constructorArgs: tokenStakingConstructorArgs,
+      }
+    )
+    tokenStakingAddress = tokenStaking.address
+    log(`Deployed TokenStaking with TransparentProxy at ${tokenStakingAddress}`)
+
+    const implementationInterface = tokenStaking.interface
+    let jsonAbi = implementationInterface.format(ethers.utils.FormatTypes.json)
+
+    const tokenStakingDeployment = {
+      address: tokenStakingAddress,
+      abi: JSON.parse(jsonAbi as string),
+    }
+    const fs = require("fs")
+    fs.writeFileSync(
+      "TokenStaking.json",
+      JSON.stringify(tokenStakingDeployment, null, 2),
+      "utf8",
+      function (err) {
+        if (err) {
+          console.log(err)
+        }
+      }
+    )
+    log(`Saved TokenStaking address and ABI in TokenStaking.json`)
+  } else {
+    const TokenStaking = await deployments.deploy("TokenStaking", {
+      from: deployer,
+      args: tokenStakingConstructorArgs,
+      log: true,
+    })
+    tokenStakingAddress = TokenStaking.address
+
+    await execute("TokenStaking", { from: deployer }, "initialize")
+    log("Initialized TokenStaking.")
+  }
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "TokenStaking",
-      address: TokenStaking.address,
+      address: tokenStakingAddress,
     })
   }
 }

--- a/deploy/07_deploy_token_staking.ts
+++ b/deploy/07_deploy_token_staking.ts
@@ -43,4 +43,5 @@ func.dependencies = [
   "VendingMachineKeep",
   "VendingMachineNuCypher",
   "KeepStake",
+  "MintT",
 ]

--- a/deploy/92_transfer_ownership_token_staking.ts
+++ b/deploy/92_transfer_ownership_token_staking.ts
@@ -1,0 +1,24 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, deployments } = hre
+  const { deployer, thresholdCouncil } = await getNamedAccounts()
+  const { execute } = deployments
+
+  await execute(
+    "TokenStaking",
+    { from: deployer },
+    "transferGovernance",
+    thresholdCouncil
+  )
+}
+
+export default func
+
+func.tags = ["TransferOwnershipTokenStaking"]
+func.runAtTheEnd = true
+func.dependencies = ["TokenStaking"]
+func.skip = async function (hre: HardhatRuntimeEnvironment): Promise<boolean> {
+  return hre.network.name !== "mainnet"
+}

--- a/deploy/93_transfer_upgradeability_token_staking.ts
+++ b/deploy/93_transfer_upgradeability_token_staking.ts
@@ -1,0 +1,19 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+import { upgrades } from "hardhat"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts } = hre
+  const { thresholdCouncil } = await getNamedAccounts()
+
+  await upgrades.admin.transferProxyAdminOwnership(thresholdCouncil)
+}
+
+export default func
+
+func.tags = ["TransferUpgradeabilityTokenStaking"]
+func.runAtTheEnd = true
+func.dependencies = ["TokenStaking"]
+func.skip = async function (hre: HardhatRuntimeEnvironment): Promise<boolean> {
+  return hre.network.name !== "mainnet"
+}

--- a/deploy/94_transfer_ownership_keep_stake.ts
+++ b/deploy/94_transfer_ownership_keep_stake.ts
@@ -1,0 +1,22 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types"
+import { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, helpers } = hre
+  const { deployer, thresholdCouncil } = await getNamedAccounts()
+
+  await helpers.ownable.transferOwnership(
+    "KeepStake",
+    thresholdCouncil,
+    deployer
+  )
+}
+
+export default func
+
+func.tags = ["TransferOwnershipKeepStake"]
+func.dependencies = ["KeepStake"]
+func.runAtTheEnd = true
+func.skip = async function (hre: HardhatRuntimeEnvironment): Promise<boolean> {
+  return hre.network.name !== "mainnet"
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -62,6 +62,14 @@ const config: HardhatUserConfig = {
         : undefined,
       tags: ["tenderly"],
     },
+    mainnet: {
+      url: process.env.CHAIN_API_URL || "",
+      chainId: 1,
+      accounts: process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY
+        ? [process.env.CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY]
+        : undefined,
+      tags: ["tenderly"],
+    },
   },
   tenderly: {
     username: "thesis",

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -105,7 +105,7 @@ const config: HardhatUserConfig = {
   namedAccounts: {
     deployer: {
       default: 0, // take the first account as deployer
-      mainnet: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
+      // mainnet: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
     },
     thresholdCouncil: {
       mainnet: "0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f",

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -100,7 +100,7 @@ const config: HardhatUserConfig = {
       mainnet: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
     },
     thresholdCouncil: {
-      mainnet: "0x00", // FIXME: Provide value
+      mainnet: "0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f",
     },
   },
   mocha: {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,12 +3,12 @@ import { HardhatUserConfig } from "hardhat/config"
 import "@keep-network/hardhat-helpers"
 import "@keep-network/hardhat-local-networks-config"
 import "@nomiclabs/hardhat-waffle"
-import "hardhat-gas-reporter"
-import "hardhat-deploy"
+import "@openzeppelin/hardhat-upgrades"
 import "@tenderly/hardhat-tenderly"
 
-require("hardhat-contract-sizer")
-require("@openzeppelin/hardhat-upgrades")
+import "hardhat-contract-sizer"
+import "hardhat-deploy"
+import "hardhat-gas-reporter"
 
 const config: HardhatUserConfig = {
   solidity: {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "deploy/",
     "export/",
     "scripts/",
+    ".openzeppelin/mainnet.json",
     "export.json"
   ],
   "scripts": {

--- a/tsconfig.export.json
+++ b/tsconfig.export.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "target": "es5",
     "esModuleInterop": true,
     "outDir": "export"
   }


### PR DESCRIPTION
* Modifies deployment script for TokenStaking for using OpenZeppelin Upgrades on mainnet
* Adds additional deployment steps for mainnet, since we need to transfer TokenStaking ownership and upgradeability control to the Threshold Council
* Adds the resulting OpenZeppelin Upgradeability Manifest, which is necessary to verify layout storage correctness of further TokenStaking upgrade