### PR TITLE
Bump up package version to `1.2.0-dev`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threshold-network/solidity-contracts",
-  "version": "1.1.0-dev",
+  "version": "1.2.0-dev",
   "license": "GPL-3.0-or-later",
   "files": [
     "artifacts/",


### PR DESCRIPTION
We already published `1.1.0` version of
`@threshold-network/solidity-contracts` package for mainnet. All new
contracts should have higher version. We're setting the version in
`package.json` to `1.2.0-dev`. This way each change to the contracts'
code will trigger the NPM workflow publishing `1.2.0-dev.0`,
1.2.0-dev.1`, ... packages (until `1.2.0` version for mainnet is not
published).