### PR TITLE
Involuntarily decrease all authorizations in case of slashing

### DIFF
--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -77,7 +77,6 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     struct SlashingEvent {
         address stakingProvider;
         uint96 amount;
-        address application;
     }
 
     uint256 internal constant SLASHING_REWARD_PERCENT = 5;
@@ -1000,8 +999,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         authorizationDecrease(
             stakingProvider,
             stakingProviderStruct,
-            slashedAmount,
-            address(0)
+            slashedAmount
         );
     }
 
@@ -1044,8 +1042,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         authorizationDecrease(
             stakingProvider,
             stakingProviderStruct,
-            slashedAmount,
-            address(0)
+            slashedAmount
         );
         decreaseStakeCheckpoint(
             stakingProvider,
@@ -1472,11 +1469,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
                 continue;
             }
             slashingQueue.push(
-                SlashingEvent(
-                    stakingProvider,
-                    amountToSlash.toUint96(),
-                    msg.sender
-                )
+                SlashingEvent(stakingProvider, amountToSlash.toUint96())
             );
         }
 
@@ -1548,8 +1541,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         authorizationDecrease(
             slashing.stakingProvider,
             stakingProviderStruct,
-            slashedAmount,
-            slashing.application
+            slashedAmount
         );
         uint96 newStake = stakingProviderStruct.tStake +
             stakingProviderStruct.keepInTStake +
@@ -1561,8 +1553,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     function authorizationDecrease(
         address stakingProvider,
         StakingProviderInfo storage stakingProviderStruct,
-        uint96 slashedAmount,
-        address application
+        uint96 slashedAmount
     ) internal {
         uint96 totalStake = stakingProviderStruct.tStake +
             stakingProviderStruct.nuInTStake +
@@ -1578,16 +1569,11 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
             AppAuthorization storage authorization = stakingProviderStruct
                 .authorizations[authorizedApplication];
             uint96 fromAmount = authorization.authorized;
-            if (
-                application == address(0) ||
-                authorizedApplication == application
-            ) {
-                authorization.authorized -= MathUpgradeable
-                    .min(fromAmount, slashedAmount)
-                    .toUint96();
-            } else if (fromAmount <= totalStake) {
-                continue;
-            }
+
+            authorization.authorized -= MathUpgradeable
+                .min(fromAmount, slashedAmount)
+                .toUint96();
+
             if (authorization.authorized > totalStake) {
                 authorization.authorized = totalStake;
             }

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -6454,12 +6454,10 @@ describe("TokenStaking", () => {
         expect(await tokenStaking.slashingQueue(0)).to.deep.equal([
           stakingProvider.address,
           amount,
-          application1Mock.address,
         ])
         expect(await tokenStaking.slashingQueue(1)).to.deep.equal([
           otherStaker.address,
           amountToSlash,
-          application1Mock.address,
         ])
         expect(await tokenStaking.getSlashingQueueLength()).to.equal(2)
       })
@@ -6520,12 +6518,10 @@ describe("TokenStaking", () => {
         expect(await tokenStaking.slashingQueue(0)).to.deep.equal([
           stakingProvider.address,
           amountToSlash,
-          application1Mock.address,
         ])
         expect(await tokenStaking.slashingQueue(1)).to.deep.equal([
           otherStaker.address,
           amountToSlash,
-          application1Mock.address,
         ])
         expect(await tokenStaking.getSlashingQueueLength()).to.equal(2)
       })
@@ -6603,12 +6599,10 @@ describe("TokenStaking", () => {
         expect(await tokenStaking.slashingQueue(0)).to.deep.equal([
           otherStaker.address,
           amountToSlash,
-          application1Mock.address,
         ])
         expect(await tokenStaking.slashingQueue(1)).to.deep.equal([
           stakingProvider.address,
           amountToSlash,
-          application1Mock.address,
         ])
         expect(await tokenStaking.getSlashingQueueLength()).to.equal(2)
       })
@@ -6643,8 +6637,7 @@ describe("TokenStaking", () => {
       it("should add one slashing event", async () => {
         expect(await tokenStaking.slashingQueue(0)).to.deep.equal([
           stakingProvider.address,
-          amountToSlash,
-          application1Mock.address,
+          amountToSlash
         ])
         expect(await tokenStaking.getSlashingQueueLength()).to.equal(1)
       })
@@ -6687,7 +6680,6 @@ describe("TokenStaking", () => {
         expect(await tokenStaking.slashingQueue(0)).to.deep.equal([
           otherStaker.address,
           amountToSlash,
-          application1Mock.address,
         ])
       })
 
@@ -7001,7 +6993,7 @@ describe("TokenStaking", () => {
           ).to.equal(0)
         })
 
-        it("should decrease authorized amount only for one application", async () => {
+        it("should decrease authorized amounts only for one provider", async () => {
           expect(
             await tokenStaking.authorizedStake(
               stakingProvider.address,
@@ -7013,7 +7005,7 @@ describe("TokenStaking", () => {
               stakingProvider.address,
               application2Mock.address
             )
-          ).to.equal(provider1Authorized2)
+          ).to.equal(provider1Authorized2.sub(amountToSlash))
           expect(
             await tokenStaking.authorizedStake(
               otherStaker.address,
@@ -7045,13 +7037,13 @@ describe("TokenStaking", () => {
           ).to.be.revertedWith("Too many applications")
         })
 
-        it("should inform only one application", async () => {
+        it("should inform all applications", async () => {
           expect(
             await application1Mock.stakingProviders(stakingProvider.address)
           ).to.deep.equal([provider1Authorized1.sub(amountToSlash), Zero])
           expect(
             await application2Mock.stakingProviders(stakingProvider.address)
-          ).to.deep.equal([provider1Authorized2, Zero])
+          ).to.deep.equal([provider1Authorized2.sub(amountToSlash), Zero])
           expect(
             await application1Mock.stakingProviders(otherStaker.address)
           ).to.deep.equal([provider2Authorized1, Zero])
@@ -7269,7 +7261,7 @@ describe("TokenStaking", () => {
     })
 
     context(
-      "when decrease authorized amount to zero for one application",
+      "when decrease authorized amount to zero",
       () => {
         const tAmount = initialStakerBalance
 
@@ -7326,7 +7318,7 @@ describe("TokenStaking", () => {
               stakingProvider.address,
               application2Mock.address
             )
-          ).to.equal(authorized)
+          ).to.equal(0)
         })
 
         it("should allow to authorize one more application", async () => {


### PR DESCRIPTION
The original approach was to decrease authorization on the slashing application and decrease authorizations on other applications only if necessary, that is, if the staked amount after the slashing was lower than the authorization on the other application. 

For example, let's assume the staking provider has 1000 T delegated and three applications authorized:

A application authorized for 950 T
B application authorized for 500 T
C application authorized for 100 T

If C slashed for 50 T, authorization on C would be reduced by 50 T, to 100 - 50 = 50 T.
If A slashed for 950 T, authorizations on A would be reduced to 0, and authorizations on B and C would be reduced to 50 T.

The new approach assumes all applications are decreasing authorizations in case of slashing, no matter which application executed the slash.

If C slashed for 50 T, authorization on A would be reduced to 950 - 50 = 900 T, authorization on B would be reduced to 500 - 50 = 450 T, and authorization on C would be reduced to 100 - 50 = 50 T.
If A slashed for 950 T, authorizations on A, B, and C would be reduced to 0 T.

Depending on how staker thinks about setting their risk profile, the first or second approach could make more sense for them. One staker could argue slashing event on one application should not affect their authorizations on other applications, and another staker would argue they set their original risk profile based on another staked amount, and given that the situations changed and they have less tokens now, the risk profile should be adjusted.

Most importantly though, this change is made to avoid storing the address of slashing application in the slashing event structure. This change allows reducing the gas cost of slashing large groups SIGNIFICANTLY given that we store one EVM word less per each member seat in the group. For a group of 64 members, it means storing 64 EVM words less. For a group of 100 members, it means storing 100 EVM words less. This is extremely important for random beacon and tBTC where signing groups have 64 and 100 operators respectively. 

This change was tested by @nkuba with the `RandomBeacon` contract's `reportUnauthorizedSigning` call with the cost of `TokenStaking.seize` extracted.

Before this change:
- for group size 64, gas cost: 3 142 093,
- for group size 100, gas cost: 4 860 500.

After this change:
- for group size 64, gas cost: 1 720 849,
- for group size 100: gas cost: 2 639 758

See https://github.com/keep-network/keep-core/pull/2903#discussion_r841539839

I recommend reviewing this PR per-commit, as the diff can be misleading because of the linting changes.
