### PR TITLE
Added minimumAuthorization function to IApplication interface

### DIFF
--- a/contracts/staking/IApplication.sol
+++ b/contracts/staking/IApplication.sol
@@ -24,7 +24,9 @@ pragma solidity 0.8.9;
 interface IApplication {
     /// @notice Used by T staking contract to inform the application that the
     ///         authorized amount for the given staking provider increased.
-    ///         The application may do any necessary housekeeping.
+    ///         The application may do any necessary housekeeping. The
+    ///         application may revert the transaction in case the authorization
+    ///         is below the minimum required.
     function authorizationIncreased(
         address stakingProvider,
         uint96 fromAmount,
@@ -54,4 +56,8 @@ interface IApplication {
         uint96 fromAmount,
         uint96 toAmount
     ) external;
+
+    /// @notice The minimum authorization amount required for the staking
+    ///         provider so that they can participate in the application.
+    function minimumAuthorization() external view returns (uint96);
 }

--- a/contracts/staking/IApplication.sol
+++ b/contracts/staking/IApplication.sol
@@ -25,8 +25,8 @@ interface IApplication {
     /// @notice Used by T staking contract to inform the application that the
     ///         authorized amount for the given staking provider increased.
     ///         The application may do any necessary housekeeping. The
-    ///         application may revert the transaction in case the authorization
-    ///         is below the minimum required.
+    ///         application must revert the transaction in case the
+    ///         authorization is below the minimum required.
     function authorizationIncreased(
         address stakingProvider,
         uint96 fromAmount,

--- a/contracts/test/TokenStakingTestSet.sol
+++ b/contracts/test/TokenStakingTestSet.sol
@@ -271,6 +271,10 @@ contract ApplicationMock is IApplication {
         }
         stakingProviderStruct.authorized = toAmount;
     }
+
+    function minimumAuthorization() external view returns (uint96) {
+        return 0;
+    } 
 }
 
 contract BrokenApplicationMock is ApplicationMock {

--- a/contracts/test/TokenStakingTestSet.sol
+++ b/contracts/test/TokenStakingTestSet.sol
@@ -274,7 +274,7 @@ contract ApplicationMock is IApplication {
 
     function minimumAuthorization() external view returns (uint96) {
         return 0;
-    } 
+    }
 }
 
 contract BrokenApplicationMock is ApplicationMock {


### PR DESCRIPTION
Refs #88 
Refs https://github.com/keep-network/keep-core/issues/2935

~~Depends on #87 (keeping as a draft until #87 is merged)~~

There is an implicit contract in `TokenStaking` that `IApplication` may
revert in case the minimum authorization requirement is not met. The
problem is that `IApplication` does not clearly define what is the minimum
authorization.

This change improves it. First, the contract about
`increaseAuthorization` reverting if the minimum requirement is not met
is now explicit. Second, `IApplication` exposes `minimumAuthorization`
information.