### PR TITLE
Fix deployment of KeepRegistryStub for external projects

### DIFF
--- a/deploy/00_resolve_keep_registry.ts
+++ b/deploy/00_resolve_keep_registry.ts
@@ -4,7 +4,7 @@ import { DeployFunction } from "hardhat-deploy/types"
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments, helpers } = hre
   const { log } = deployments
-  const { keepDeployer } = await getNamedAccounts()
+  const { deployer } = await getNamedAccounts()
 
   const KeepRegistry = await deployments.getOrNull("KeepRegistry")
 
@@ -20,7 +20,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     await deployments.deploy("KeepRegistry", {
       contract: "KeepRegistryStub",
-      from: keepDeployer,
+      from: deployer,
       log: true,
     })
   }

--- a/deploy/08_configure_keep_registry.ts
+++ b/deploy/08_configure_keep_registry.ts
@@ -3,20 +3,20 @@ import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments } = hre
-  const { keepDeployer } = await getNamedAccounts()
+  const { keepRegistryKeeper } = await getNamedAccounts()
   const { execute, log } = deployments
 
   const TokenStaking = await deployments.get("TokenStaking")
 
   await execute(
     "KeepRegistry",
-    { from: keepDeployer },
+    { from: keepRegistryKeeper },
     "approveOperatorContract",
     TokenStaking.address
   )
 
   log(
-    `Approved T TokenStaking operator contract [${TokenStaking.address}] in Keep registry`
+    `Approved T TokenStaking operator contract [${TokenStaking.address}] in KeepRegistry`
   )
 }
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -113,8 +113,8 @@ const config: HardhatUserConfig = {
     thresholdCouncil: {
       mainnet: "0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f",
     },
-    keepDeployer: {
-      default: 0,
+    keepRegistryKeeper: {
+      default: 0, // same as the deployer
       ropsten: "0x923C5Dbf353e99394A21Aa7B67F3327Ca111C67D",
     },
   },


### PR DESCRIPTION
When a KeepRegistry deployed contract is not found for local network we
wan to deploy a stub. The script can also be used by external projects
to deploy threshold network contract dependencies. When we used
`keepDeployer` the external projects deployment was failing as it
required the account to be defined also in the other project's hardhat
configuration file. To fix that we use `deployer` named account to
deploy the stub, as it will for sure be defined in other projects.

To call the `approveOperatorContract` we use `keepRegistryKeeper` which
is defined by default as account `0` and it matches the `deployer`.