### PR TITLE
Use deployer as a fallback to call approveOperatorContract

### DIFF
--- a/deploy/08_configure_keep_registry.ts
+++ b/deploy/08_configure_keep_registry.ts
@@ -3,14 +3,14 @@ import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments } = hre
-  const { keepRegistryKeeper } = await getNamedAccounts()
+  const { keepRegistryKeeper, deployer } = await getNamedAccounts()
   const { execute, log } = deployments
 
   const TokenStaking = await deployments.get("TokenStaking")
 
   await execute(
     "KeepRegistry",
-    { from: keepRegistryKeeper },
+    { from: keepRegistryKeeper || deployer },
     "approveOperatorContract",
     TokenStaking.address
   )


### PR DESCRIPTION
For ropsten we expect that approveOperatorContract will be called by the
account that is defined as `keepRegistryKeeper` in the hardhat config,
but for hardhat local network and for usage in external project it's
just fine to assume the `deployer` will be used as a fallback, so the
external project doesn't have to define `keepRegistryKeeper`.

This is a continuation of https://github.com/threshold-network/solidity-contracts/pull/92