### PR TITLE
Expand NPM workflow triggers

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - "contracts/**"
+      - "deploy/**"
+      - "hardhat.config.ts"
       - "package.json"
       - "yarn.lock"
   workflow_dispatch:


### PR DESCRIPTION
We want to publish the new NPM package tagged with `develop` every time
changes affecting contracts get merged to `main`. We already trigger
the workflow when changes are applied in
- `"contracts/**"`
- `"package.json"`
- `"yarn.lock"`

but it also makes sense to trigger the workflow when there are changes
in
- `"deploy/**"`
- `"hardhat.config.ts"`

as they also can affect the content of the exported package with the
contracts.