### PR TITLE
Added reward-related functions to IApplication interface

### DIFF
--- a/contracts/staking/IApplication.sol
+++ b/contracts/staking/IApplication.sol
@@ -22,6 +22,15 @@ pragma solidity 0.8.9;
 ///         staking provider are eligible to slash the stake delegated to that
 ///         staking provider.
 interface IApplication {
+    /// @dev Event emitted by `withdrawRewards` function.
+    event RewardsWithdrawn(address indexed stakingProvider, uint96 amount);
+
+    /// @notice Withdraws application rewards for the given staking provider.
+    ///         Rewards are withdrawn to the staking provider's beneficiary
+    ///         address set in the staking contract.
+    /// @dev Emits `RewardsWithdrawn` event.
+    function withdrawRewards(address stakingProvider) external;
+
     /// @notice Used by T staking contract to inform the application that the
     ///         authorized amount for the given staking provider increased.
     ///         The application may do any necessary housekeeping. The
@@ -56,6 +65,13 @@ interface IApplication {
         uint96 fromAmount,
         uint96 toAmount
     ) external;
+
+    /// @notice Returns the amount of application rewards available for
+    ///         withdrawal for the given staking provider.
+    function availableRewards(address stakingProvider)
+        external
+        view
+        returns (uint96);
 
     /// @notice The minimum authorization amount required for the staking
     ///         provider so that they can participate in the application.

--- a/contracts/test/TokenStakingTestSet.sol
+++ b/contracts/test/TokenStakingTestSet.sol
@@ -209,6 +209,10 @@ contract ApplicationMock is IApplication {
         tokenStaking = _tokenStaking;
     }
 
+    function withdrawRewards(address) external {
+        // does nothing
+    }
+
     function authorizationIncreased(
         address stakingProvider,
         uint96,
@@ -272,7 +276,11 @@ contract ApplicationMock is IApplication {
         stakingProviderStruct.authorized = toAmount;
     }
 
-    function minimumAuthorization() external view returns (uint96) {
+    function availableRewards(address) external pure returns (uint96) {
+        return 0;
+    }
+
+    function minimumAuthorization() external pure returns (uint96) {
         return 0;
     }
 }


### PR DESCRIPTION
Closes #89

The interface is minimal and does not enforce any specific requirements on how the rewards are actually accrued.

`function withdrawRewards(address stakingProvider) external` withdraws application rewards for the given staking provider. Rewards are withdrawn to the staking provider's beneficiary address set in the staking contract. Function emits `RewardsWithdrawn(address indexed stakingProvider, uint96 amount)` so that applications can easily track the total amount of rewards accrued so far.

`function availableRewards(address stakingProvider)` Returns the amount of application rewards available for withdrawal for the given staking provider.