### PR TITLE
Define dependency to @openzeppelin/contracts as ~4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
   },
   "dependencies": {
     "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
-    "@openzeppelin/contracts": "^4.5",
-    "@openzeppelin/contracts-upgradeable": "^4.5",
+    "@openzeppelin/contracts": "~4.5.0",
+    "@openzeppelin/contracts-upgradeable": "~4.5.2",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -617,12 +617,12 @@
     "@types/sinon-chai" "^3.2.3"
     "@types/web3" "1.0.19"
 
-"@openzeppelin/contracts-upgradeable@^4.5":
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.1.tgz#dc354082460eb34f5833afdecfab46538b208c4f"
-  integrity sha512-xcKycsSyFauIGMhSeeTJW/Jzz9jZUJdiFNP9Wo/9VhMhw8t5X0M92RY6x176VfcIWsxURMHFWOJVTlFA78HI/w==
+"@openzeppelin/contracts-upgradeable@~4.5.2":
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.5.2.tgz#90d9e47bacfd8693bfad0ac8a394645575528d05"
+  integrity sha512-xgWZYaPlrEOQo3cBj97Ufiuv79SPd8Brh4GcFYhPgb6WvAq4ppz8dWKL6h+jLAK01rUqMRp/TS9AdXgAeNvCLA==
 
-"@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@^4.5":
+"@openzeppelin/contracts@^4.1.0", "@openzeppelin/contracts@~4.5.0":
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.5.0.tgz#3fd75d57de172b3743cdfc1206883f56430409cc"
   integrity sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==


### PR DESCRIPTION
With `^4.5` a version `4.6.0` was resolved during installation which is incompatible due to changes in the `@openzeppelin/contracts/governance/Governor` contract.
We want to stick with `4.5` with patches, hence `~`.