### PR TITLE
Workaround ethers import in deployment script for a bug in hardhat-ethers-plugin

### DIFF
--- a/deploy/30_deploy_tokenholder_timelock.ts
+++ b/deploy/30_deploy_tokenholder_timelock.ts
@@ -1,8 +1,13 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
+// FIXME: As a workaround for a bug in hardhat-gas-reporter #86 we import
+// ethers here instead of using the one defined in `hre`.
+// #86: https://github.com/cgewecke/hardhat-gas-reporter/issues/86
+import { ethers } from "ethers"
+
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { getNamedAccounts, deployments, ethers } = hre
+  const { getNamedAccounts, deployments } = hre
   const { deployer } = await getNamedAccounts()
 
   const proposers = []

--- a/deploy/31_deploy_tokenholder_governor.ts
+++ b/deploy/31_deploy_tokenholder_governor.ts
@@ -2,7 +2,7 @@ import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { getNamedAccounts, deployments, ethers } = hre
+  const { getNamedAccounts, deployments } = hre
   const { deployer, thresholdCouncil } = await getNamedAccounts()
 
   // TODO: fail if thresholdCouncil is undefined on mainnet

--- a/deploy/32_configure_tokenholder_timelock.ts
+++ b/deploy/32_configure_tokenholder_timelock.ts
@@ -2,7 +2,7 @@ import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { getNamedAccounts, deployments, ethers } = hre
+  const { getNamedAccounts, deployments } = hre
   const { deployer } = await getNamedAccounts()
   const { execute, read, log } = deployments
 


### PR DESCRIPTION
This PR is a workaround for an issue with `hardhat-gas-reporter` plugin (https://github.com/cgewecke/hardhat-gas-reporter/issues/86).

When `hre.ethers` is used in the deployment script it causes a gas report to be missing executed function's data ([example](https://github.com/cgewecke/hardhat-gas-reporter/issues/86#issuecomment-1114700353)).

For tests executed in this repository, reports are fine, but when we use `@threshold-network/solidity-contracts` as a dependency in other projects (e.g. `@keep-network/ecdsa`) it breaks the reports there.