### PR TITLE
Deploy `SimplePREApplicationStub` contract

### DIFF
--- a/contracts/test/SimplePREApplicationStub.sol
+++ b/contracts/test/SimplePREApplicationStub.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+pragma solidity ^0.8.0;
+
+contract SimplePREApplicationStub {
+    event OperatorConfirmed(
+        address indexed stakingProvider,
+        address indexed operator
+    );
+
+    function confirmOperatorAddress(address stakingProvider) external {
+        emit OperatorConfirmed(stakingProvider, msg.sender);
+    }
+}

--- a/deploy/00_resolve_nucypher_pre_application.ts
+++ b/deploy/00_resolve_nucypher_pre_application.ts
@@ -1,0 +1,23 @@
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
+
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { getNamedAccounts, deployments } = hre
+  const { log } = deployments
+  const { deployer } = await getNamedAccounts()
+
+  log(`deploying SimplePREApplication stub`)
+
+  await deployments.deploy("SimplePREApplication", {
+    contract: "SimplePREApplicationStub",
+    from: deployer,
+    log: true,
+  })
+}
+
+export default func
+
+func.tags = ["NuCypherSimplePREApplication"]
+func.skip = async function (hre: HardhatRuntimeEnvironment): Promise<boolean> {
+  return hre.network.name !== "development"
+}


### PR DESCRIPTION
Ref: https://github.com/threshold-network/token-dashboard/pull/107

Add script that deploys the `SimplePREApplicationStub` contract to test
the integration with this contract locally in T dapp. This script will
only run for `development` network.