### PR TITLE
Add bondOperator function to PRE stub

### DIFF
--- a/contracts/test/SimplePREApplicationStub.sol
+++ b/contracts/test/SimplePREApplicationStub.sol
@@ -22,14 +22,22 @@ contract SimplePREApplicationStub {
 
     mapping(address => StakingProviderInfo) public stakingProviderInfo;
 
-
-    function bondOperator(address _stakingProvider, address _operator) external {
-        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
-        require(_operator != info.operator, "Specified operator is already bonded with this provider");
+    function bondOperator(address _stakingProvider, address _operator)
+        external
+    {
+        StakingProviderInfo storage info = stakingProviderInfo[
+            _stakingProvider
+        ];
+        require(
+            _operator != info.operator,
+            "Specified operator is already bonded with this provider"
+        );
         // Bond new operator (or unbond if _operator == address(0))
         info.operator = _operator;
+        /* solhint-disable-next-line not-rely-on-time */
         info.operatorStartTimestamp = block.timestamp;
         info.operatorConfirmed = false;
+        /* solhint-disable-next-line not-rely-on-time */
         emit OperatorBonded(_stakingProvider, _operator, block.timestamp);
     }
 

--- a/contracts/test/SimplePREApplicationStub.sol
+++ b/contracts/test/SimplePREApplicationStub.sol
@@ -47,9 +47,6 @@ contract SimplePREApplicationStub {
             !info.operatorConfirmed,
             "Operator address is already confirmed"
         );
-        info.operator = msg.sender;
-        /* solhint-disable-next-line not-rely-on-time */
-        info.operatorStartTimestamp = block.timestamp;
         info.operatorConfirmed = true;
         emit OperatorConfirmed(stakingProvider, msg.sender);
     }

--- a/contracts/test/SimplePREApplicationStub.sol
+++ b/contracts/test/SimplePREApplicationStub.sol
@@ -3,6 +3,12 @@
 pragma solidity ^0.8.0;
 
 contract SimplePREApplicationStub {
+    event OperatorBonded(
+        address indexed stakingProvider,
+        address indexed operator,
+        uint256 startTimestamp
+    );
+
     event OperatorConfirmed(
         address indexed stakingProvider,
         address indexed operator
@@ -15,6 +21,17 @@ contract SimplePREApplicationStub {
     }
 
     mapping(address => StakingProviderInfo) public stakingProviderInfo;
+
+
+    function bondOperator(address _stakingProvider, address _operator) external {
+        StakingProviderInfo storage info = stakingProviderInfo[_stakingProvider];
+        require(_operator != info.operator, "Specified operator is already bonded with this provider");
+        // Bond new operator (or unbond if _operator == address(0))
+        info.operator = _operator;
+        info.operatorStartTimestamp = block.timestamp;
+        info.operatorConfirmed = false;
+        emit OperatorBonded(_stakingProvider, _operator, block.timestamp);
+    }
 
     function confirmOperatorAddress(address stakingProvider) external {
         StakingProviderInfo storage info = stakingProviderInfo[stakingProvider];


### PR DESCRIPTION
This change is needed to test token-dashboard properly.

Changes:
- add `bondOperator` function and `OperatorBonded` event to
`SimplePREApplicationStub` contract. 
- remove setting `operator` and `operatorStartTimestamp` values in 
`confirmOperatorAddress` since we are doing it in `bondOperator` func.