### PR TITLE
Adding `development` network for local development

### DIFF
--- a/deploy/00_resolve_keep_registry.ts
+++ b/deploy/00_resolve_keep_registry.ts
@@ -11,13 +11,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepRegistry && helpers.address.isValid(KeepRegistry.address)) {
     log(`using existing KeepRegistry contract at ${KeepRegistry.address}`)
   } else if (
-    hre.network.name === "hardhat" &&
-    (hre.network.config as HardhatNetworkConfig).forking.enabled
-  ) {
-    throw new Error("deployed KeepRegistry contract not found")
-  } else if (
-    hre.network.name !== "hardhat" &&
-    hre.network.name !== "development"
+    (hre.network.name === "hardhat" &&
+      (hre.network.config as HardhatNetworkConfig).forking.enabled) ||
+    (hre.network.name !== "hardhat" && hre.network.name !== "development")
   ) {
     throw new Error("deployed KeepRegistry contract not found")
   } else {

--- a/deploy/00_resolve_keep_registry.ts
+++ b/deploy/00_resolve_keep_registry.ts
@@ -11,8 +11,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepRegistry && helpers.address.isValid(KeepRegistry.address)) {
     log(`using existing KeepRegistry contract at ${KeepRegistry.address}`)
   } else if (
-    !hre.network.tags.local ||
+    hre.network.name === "hardhat" &&
     (hre.network.config as HardhatNetworkConfig).forking.enabled
+  ) {
+    throw new Error("deployed KeepRegistry contract not found")
+  } else if (
+    hre.network.name !== "hardhat" &&
+    hre.network.name !== "development"
   ) {
     throw new Error("deployed KeepRegistry contract not found")
   } else {

--- a/deploy/00_resolve_keep_registry.ts
+++ b/deploy/00_resolve_keep_registry.ts
@@ -11,8 +11,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepRegistry && helpers.address.isValid(KeepRegistry.address)) {
     log(`using existing KeepRegistry contract at ${KeepRegistry.address}`)
   } else if (
-    (hre.network.config as HardhatNetworkConfig)?.forking.enabled ||
-    (hre.network.name !== "hardhat" && hre.network.name !== "development")
+    (!hre.network.tags.allowStubs) ||
+    (hre.network.config as HardhatNetworkConfig)?.forking.enabled 
   ) {
     throw new Error("deployed KeepRegistry contract not found")
   } else {

--- a/deploy/00_resolve_keep_registry.ts
+++ b/deploy/00_resolve_keep_registry.ts
@@ -11,8 +11,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepRegistry && helpers.address.isValid(KeepRegistry.address)) {
     log(`using existing KeepRegistry contract at ${KeepRegistry.address}`)
   } else if (
-    (hre.network.name === "hardhat" &&
-      (hre.network.config as HardhatNetworkConfig).forking.enabled) ||
+    (hre.network.config as HardhatNetworkConfig)?.forking.enabled ||
     (hre.network.name !== "hardhat" && hre.network.name !== "development")
   ) {
     throw new Error("deployed KeepRegistry contract not found")

--- a/deploy/00_resolve_keep_registry.ts
+++ b/deploy/00_resolve_keep_registry.ts
@@ -11,7 +11,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepRegistry && helpers.address.isValid(KeepRegistry.address)) {
     log(`using existing KeepRegistry contract at ${KeepRegistry.address}`)
   } else if (
-    hre.network.name !== "hardhat" ||
+    !hre.network.tags.local ||
     (hre.network.config as HardhatNetworkConfig).forking.enabled
   ) {
     throw new Error("deployed KeepRegistry contract not found")

--- a/deploy/00_resolve_keep_registry.ts
+++ b/deploy/00_resolve_keep_registry.ts
@@ -11,8 +11,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepRegistry && helpers.address.isValid(KeepRegistry.address)) {
     log(`using existing KeepRegistry contract at ${KeepRegistry.address}`)
   } else if (
-    (!hre.network.tags.allowStubs) ||
-    (hre.network.config as HardhatNetworkConfig)?.forking.enabled 
+    !hre.network.tags.allowStubs ||
+    (hre.network.config as HardhatNetworkConfig)?.forking.enabled
   ) {
     throw new Error("deployed KeepRegistry contract not found")
   } else {

--- a/deploy/00_resolve_keep_token.ts
+++ b/deploy/00_resolve_keep_token.ts
@@ -16,8 +16,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // Save deployment artifact of external contract to include it in the package.
     await deployments.save("KeepToken", KeepToken)
   } else if (
-    !hre.network.tags.local ||
-    (hre.network.config as HardhatNetworkConfig).forking?.enabled
+    hre.network.name === "hardhat" &&
+    (hre.network.config as HardhatNetworkConfig).forking.enabled
+  ) {
+    throw new Error("deployed KeepToken contract not found")
+  } else if (
+    hre.network.name !== "hardhat" &&
+    hre.network.name !== "development"
   ) {
     throw new Error("deployed KeepToken contract not found")
   } else {

--- a/deploy/00_resolve_keep_token.ts
+++ b/deploy/00_resolve_keep_token.ts
@@ -16,7 +16,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // Save deployment artifact of external contract to include it in the package.
     await deployments.save("KeepToken", KeepToken)
   } else if (
-    hre.network.name !== "hardhat" ||
+    !hre.network.tags.local ||
     (hre.network.config as HardhatNetworkConfig).forking?.enabled
   ) {
     throw new Error("deployed KeepToken contract not found")

--- a/deploy/00_resolve_keep_token.ts
+++ b/deploy/00_resolve_keep_token.ts
@@ -16,13 +16,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // Save deployment artifact of external contract to include it in the package.
     await deployments.save("KeepToken", KeepToken)
   } else if (
-    hre.network.name === "hardhat" &&
-    (hre.network.config as HardhatNetworkConfig).forking.enabled
-  ) {
-    throw new Error("deployed KeepToken contract not found")
-  } else if (
-    hre.network.name !== "hardhat" &&
-    hre.network.name !== "development"
+    (hre.network.name === "hardhat" &&
+      (hre.network.config as HardhatNetworkConfig).forking.enabled) ||
+    (hre.network.name !== "hardhat" && hre.network.name !== "development")
   ) {
     throw new Error("deployed KeepToken contract not found")
   } else {

--- a/deploy/00_resolve_keep_token.ts
+++ b/deploy/00_resolve_keep_token.ts
@@ -16,8 +16,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // Save deployment artifact of external contract to include it in the package.
     await deployments.save("KeepToken", KeepToken)
   } else if (
-    (hre.network.config as HardhatNetworkConfig)?.forking.enabled ||
-    (hre.network.name !== "hardhat" && hre.network.name !== "development")
+    (!hre.network.tags.allowStubs) ||
+    (hre.network.config as HardhatNetworkConfig)?.forking.enabled
   ) {
     throw new Error("deployed KeepToken contract not found")
   } else {

--- a/deploy/00_resolve_keep_token.ts
+++ b/deploy/00_resolve_keep_token.ts
@@ -16,7 +16,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // Save deployment artifact of external contract to include it in the package.
     await deployments.save("KeepToken", KeepToken)
   } else if (
-    (!hre.network.tags.allowStubs) ||
+    !hre.network.tags.allowStubs ||
     (hre.network.config as HardhatNetworkConfig)?.forking.enabled
   ) {
     throw new Error("deployed KeepToken contract not found")

--- a/deploy/00_resolve_keep_token.ts
+++ b/deploy/00_resolve_keep_token.ts
@@ -16,8 +16,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // Save deployment artifact of external contract to include it in the package.
     await deployments.save("KeepToken", KeepToken)
   } else if (
-    (hre.network.name === "hardhat" &&
-      (hre.network.config as HardhatNetworkConfig).forking.enabled) ||
+    (hre.network.config as HardhatNetworkConfig)?.forking.enabled ||
     (hre.network.name !== "hardhat" && hre.network.name !== "development")
   ) {
     throw new Error("deployed KeepToken contract not found")

--- a/deploy/00_resolve_keep_token_staking.ts
+++ b/deploy/00_resolve_keep_token_staking.ts
@@ -11,8 +11,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepTokenStaking && helpers.address.isValid(KeepTokenStaking.address)) {
     log(`using existing KeepTokenStaking at ${KeepTokenStaking.address}`)
   } else if (
-    (hre.network.config as HardhatNetworkConfig)?.forking.enabled ||
-    (hre.network.name !== "hardhat" && hre.network.name !== "development")
+    (!hre.network.tags.allowStubs) || 
+    (hre.network.config as HardhatNetworkConfig)?.forking.enabled
   ) {
     throw new Error("deployed KeepTokenStaking contract not found")
   } else {

--- a/deploy/00_resolve_keep_token_staking.ts
+++ b/deploy/00_resolve_keep_token_staking.ts
@@ -11,13 +11,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepTokenStaking && helpers.address.isValid(KeepTokenStaking.address)) {
     log(`using existing KeepTokenStaking at ${KeepTokenStaking.address}`)
   } else if (
-    hre.network.name === "hardhat" &&
-    (hre.network.config as HardhatNetworkConfig).forking.enabled
-  ) {
-    throw new Error("deployed KeepTokenStaking contract not found")
-  } else if (
-    hre.network.name !== "hardhat" &&
-    hre.network.name !== "development"
+    (hre.network.name === "hardhat" &&
+      (hre.network.config as HardhatNetworkConfig).forking.enabled) ||
+    (hre.network.name !== "hardhat" && hre.network.name !== "development")
   ) {
     throw new Error("deployed KeepTokenStaking contract not found")
   } else {

--- a/deploy/00_resolve_keep_token_staking.ts
+++ b/deploy/00_resolve_keep_token_staking.ts
@@ -11,8 +11,13 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepTokenStaking && helpers.address.isValid(KeepTokenStaking.address)) {
     log(`using existing KeepTokenStaking at ${KeepTokenStaking.address}`)
   } else if (
-    !hre.network.tags.local ||
+    hre.network.name === "hardhat" &&
     (hre.network.config as HardhatNetworkConfig).forking.enabled
+  ) {
+    throw new Error("deployed KeepTokenStaking contract not found")
+  } else if (
+    hre.network.name !== "hardhat" &&
+    hre.network.name !== "development"
   ) {
     throw new Error("deployed KeepTokenStaking contract not found")
   } else {

--- a/deploy/00_resolve_keep_token_staking.ts
+++ b/deploy/00_resolve_keep_token_staking.ts
@@ -11,7 +11,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepTokenStaking && helpers.address.isValid(KeepTokenStaking.address)) {
     log(`using existing KeepTokenStaking at ${KeepTokenStaking.address}`)
   } else if (
-    (!hre.network.tags.allowStubs) || 
+    !hre.network.tags.allowStubs ||
     (hre.network.config as HardhatNetworkConfig)?.forking.enabled
   ) {
     throw new Error("deployed KeepTokenStaking contract not found")

--- a/deploy/00_resolve_keep_token_staking.ts
+++ b/deploy/00_resolve_keep_token_staking.ts
@@ -11,8 +11,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepTokenStaking && helpers.address.isValid(KeepTokenStaking.address)) {
     log(`using existing KeepTokenStaking at ${KeepTokenStaking.address}`)
   } else if (
-    (hre.network.name === "hardhat" &&
-      (hre.network.config as HardhatNetworkConfig).forking.enabled) ||
+    (hre.network.config as HardhatNetworkConfig)?.forking.enabled ||
     (hre.network.name !== "hardhat" && hre.network.name !== "development")
   ) {
     throw new Error("deployed KeepTokenStaking contract not found")

--- a/deploy/00_resolve_keep_token_staking.ts
+++ b/deploy/00_resolve_keep_token_staking.ts
@@ -11,7 +11,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   if (KeepTokenStaking && helpers.address.isValid(KeepTokenStaking.address)) {
     log(`using existing KeepTokenStaking at ${KeepTokenStaking.address}`)
   } else if (
-    hre.network.name !== "hardhat" ||
+    !hre.network.tags.local ||
     (hre.network.config as HardhatNetworkConfig).forking.enabled
   ) {
     throw new Error("deployed KeepTokenStaking contract not found")

--- a/deploy/00_resolve_nucypher_staking_escrow.ts
+++ b/deploy/00_resolve_nucypher_staking_escrow.ts
@@ -27,7 +27,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // TODO: For ropsten currently we deploy a stub contract. We should consider
     // switching to an actual contract.
     hre.network.name !== "ropsten" &&
-    (!hre.network.tags.local ||
+    (!hre.network.tags.allowStubs ||
       (hre.network.config as HardhatNetworkConfig).forking?.enabled)
   ) {
     throw new Error("deployed NuCypherStakingEscrow contract not found")

--- a/deploy/00_resolve_nucypher_token.ts
+++ b/deploy/00_resolve_nucypher_token.ts
@@ -22,7 +22,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // TODO: For ropsten currently we deploy a stub contract. We should consider
     // switching to an actual contract.
     hre.network.name !== "ropsten" &&
-    (!hre.network.tags.local ||
+    (!hre.network.tags.allowStubs ||
       (hre.network.config as HardhatNetworkConfig).forking?.enabled)
   ) {
     throw new Error("deployed NuCypherToken contract not found")

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,12 +38,12 @@ const config: HardhatUserConfig = {
           ? parseInt(process.env.FORKING_BLOCK)
           : undefined,
       },
-      tags: ["local"],
+      tags: ["allowStubs"],
     },
     development: {
       url: "http://localhost:8545",
       chainId: 1101,
-      tags: ["local"],
+      tags: ["allowStubs"],
     },
     rinkeby: {
       url: process.env.CHAIN_API_URL || "",


### PR DESCRIPTION
We also need to run Geth locally for development purposes. For this, we need to allow `*Stub` contracts to be deployed on the local chain, otherwise, it will throw an error if the local network is not `hardhat`. This PR adds `development` network which runs on localhost and Geth can be run locally.

Refs https://github.com/keep-network/keep-core/issues/3011