### PR TITLE
Update deployment scripts for resolving Keep Network V1 contracts for local development

### DIFF
--- a/deploy/00_resolve_keep_registry.ts
+++ b/deploy/00_resolve_keep_registry.ts
@@ -12,7 +12,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`using existing KeepRegistry contract at ${KeepRegistry.address}`)
   } else if (
     !hre.network.tags.allowStubs ||
-    (hre.network.config as HardhatNetworkConfig)?.forking.enabled
+    (hre.network.config as HardhatNetworkConfig)?.forking?.enabled
   ) {
     throw new Error("deployed KeepRegistry contract not found")
   } else {

--- a/deploy/00_resolve_keep_token.ts
+++ b/deploy/00_resolve_keep_token.ts
@@ -17,7 +17,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     await deployments.save("KeepToken", KeepToken)
   } else if (
     !hre.network.tags.allowStubs ||
-    (hre.network.config as HardhatNetworkConfig)?.forking.enabled
+    (hre.network.config as HardhatNetworkConfig)?.forking?.enabled
   ) {
     throw new Error("deployed KeepToken contract not found")
   } else {

--- a/deploy/00_resolve_keep_token_staking.ts
+++ b/deploy/00_resolve_keep_token_staking.ts
@@ -12,7 +12,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     log(`using existing KeepTokenStaking at ${KeepTokenStaking.address}`)
   } else if (
     !hre.network.tags.allowStubs ||
-    (hre.network.config as HardhatNetworkConfig)?.forking.enabled
+    (hre.network.config as HardhatNetworkConfig)?.forking?.enabled
   ) {
     throw new Error("deployed KeepTokenStaking contract not found")
   } else {

--- a/deploy/00_resolve_nucypher_staking_escrow.ts
+++ b/deploy/00_resolve_nucypher_staking_escrow.ts
@@ -28,7 +28,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // switching to an actual contract.
     hre.network.name !== "ropsten" &&
     (!hre.network.tags.allowStubs ||
-      (hre.network.config as HardhatNetworkConfig).forking?.enabled)
+      (hre.network.config as HardhatNetworkConfig)?.forking?.enabled)
   ) {
     throw new Error("deployed NuCypherStakingEscrow contract not found")
   } else {

--- a/deploy/00_resolve_nucypher_token.ts
+++ b/deploy/00_resolve_nucypher_token.ts
@@ -23,7 +23,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // switching to an actual contract.
     hre.network.name !== "ropsten" &&
     (!hre.network.tags.allowStubs ||
-     (hre.network.config as HardhatNetworkConfig)?.forking?.enabled)
+      (hre.network.config as HardhatNetworkConfig)?.forking?.enabled)
   ) {
     throw new Error("deployed NuCypherToken contract not found")
   } else {

--- a/deploy/00_resolve_nucypher_token.ts
+++ b/deploy/00_resolve_nucypher_token.ts
@@ -23,7 +23,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     // switching to an actual contract.
     hre.network.name !== "ropsten" &&
     (!hre.network.tags.allowStubs ||
-      (hre.network.config as HardhatNetworkConfig).forking?.enabled)
+     (hre.network.config as HardhatNetworkConfig)?.forking?.enabled)
   ) {
     throw new Error("deployed NuCypherToken contract not found")
   } else {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -83,7 +83,7 @@ const config: HardhatUserConfig = {
   external: {
     contracts: [
       {
-        // Due to a limitation of `hardhat-deploy` plugin limitation, we have
+        // Due to a limitation of `hardhat-deploy` plugin, we have
         // to modify the artifacts imported from NPM. Please see
         // `scripts/prepare-dependencies.sh` for details.
         artifacts: "external/npm/@keep-network/keep-core/artifacts",
@@ -96,8 +96,9 @@ const config: HardhatUserConfig = {
       // to the contract artifacts.
       hardhat: process.env.FORKING_URL ? ["./external/mainnet"] : [],
       // For development environment we expect the local dependencies to be linked
-      // with `yarn link` command.
-      development: ["external/npm/@keep-network/keep-core/artifacts"],
+      // with `yarn link` command, uncomment the line below to use the linked
+      // dependencies.
+      // development: ["external/npm/@keep-network/keep-core/artifacts"],
       ropsten: ["external/npm/@keep-network/keep-core/artifacts"],
       mainnet: ["./external/mainnet"],
     },


### PR DESCRIPTION
For now, as we set up local development environments we need to disable the reading of Keep Network V1 contracts deployment. For now, we will use stubs for local development.