### PR TITLE
Add support for deployment on Goerli testnet

### DIFF
--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -44,20 +44,19 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # TODO: uncomment below block of code before merge to main
-      # - uses: actions/setup-node@v2
-      #   with:
-      #     node-version: "14.x"
-      #     cache: "yarn"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          cache: "yarn"
 
-      # - name: Install dependencies
-      #   run: yarn install
+      - name: Install dependencies
+        run: yarn install
 
-      # - name: Build contracts
-      #   run: yarn build
+      - name: Build contracts
+        run: yarn build
 
-      # - name: Run tests
-      #   run: yarn test
+      - name: Run tests
+        run: yarn test
 
   contracts-system-tests:
     needs: contracts-detect-changes
@@ -105,50 +104,45 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      # TODO: uncomment below block of code before merge to main
-      # - uses: actions/setup-node@v2
-      #   with:
-      #     node-version: "14.x"
-      #     cache: "yarn"
-      #     registry-url: "https://registry.npmjs.org"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
 
-      # - name: Install dependencies
-      #   run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-      # - name: Resolve latest contracts
-      #   run: yarn upgrade @keep-network/keep-core@1.8.1-goerli.0
+      - name: Resolve latest contracts
+        run: yarn upgrade @keep-network/keep-core@1.8.1-goerli.0
 
-      # - name: Configure tenderly
-      #   env:
-      #     TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
-      #   run: ./config_tenderly.sh
+      - name: Configure tenderly
+        env:
+          TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
+        run: ./config_tenderly.sh
 
-      # - name: Deploy contracts
-      #   env:
-      #     CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-      #     CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-      #     KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-      #   run: yarn deploy --network ${{ github.event.inputs.environment }}
+      - name: Deploy contracts
+        env:
+          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+        run: yarn deploy --network ${{ github.event.inputs.environment }}
 
-      # - name: Bump up package version
-      #   id: npm-version-bump
-      #   uses: keep-network/npm-version-bump@v2
-      #   with:
-      #     environment: ${{ github.event.inputs.environment }}
-      #     branch: ${{ github.ref }}
-      #     commit: ${{ github.sha }}
+      - name: Bump up package version
+        id: npm-version-bump
+        uses: keep-network/npm-version-bump@v2
+        with:
+          environment: ${{ github.event.inputs.environment }}
+          branch: ${{ github.ref }}
+          commit: ${{ github.sha }}
 
-      # - name: Publish to npm
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      #   # TODO: remove `--dry-run` before merge to main
-      #   run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }} --dry-run
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }}
 
-      # TODO: restore commented out `uses` config before merge to `main``
       - name: Notify CI about completion of the workflow
-        # uses: keep-network/ci/actions/notify-workflow-completed@v1
-        uses: keep-network/ci/actions/notify-workflow-completed@main
-        continue-on-error: true # TODO: remove before merge to main
+        uses: keep-network/ci/actions/notify-workflow-completed@v2
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -99,7 +99,7 @@ jobs:
 
   contracts-deployment-testnet:
     needs: [contracts-build-and-test]
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'goerli'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -113,15 +113,7 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      # Ultimately, we want to get rid of steps deploying on Ropsten (as it will
-      # be shut down in Q4 2022) and switch to deployment on Goerli. We're
-      # leaving both deployment options for the transition period.
-      - name: Resolve latest contracts on Ropsten
-        if: github.event.inputs.environment == 'ropsten'
-        run: yarn upgrade @keep-network/keep-core@1.8.0-ropsten.16
-
-      - name: Resolve latest contracts on Goerli
-        if: github.event.inputs.environment == 'goerli'
+      - name: Resolve latest contracts
         run: yarn upgrade @keep-network/keep-core@1.8.1-goerli.0
 
       - name: Configure tenderly
@@ -129,16 +121,7 @@ jobs:
           TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
         run: ./config_tenderly.sh
 
-      - name: Deploy contracts on Ropsten
-        if: github.event.inputs.environment == 'ropsten'
-        env:
-          CHAIN_API_URL: ${{ secrets.ROPSTEN_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.ROPSTEN_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.ROPSTEN_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-        run: yarn deploy --network ${{ github.event.inputs.environment }}
-      
-      - name: Deploy contracts on Goerli
-        if: github.event.inputs.environment == 'goerli'
+      - name: Deploy contracts
         env:
           CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
@@ -163,6 +146,7 @@ jobs:
       - name: Notify CI about completion of the workflow
         # uses: keep-network/ci/actions/notify-workflow-completed@v1
         uses: keep-network/ci/actions/notify-workflow-completed@ci-goerli
+        continue-on-error: true # TODO: remove before merge to main
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -211,7 +195,7 @@ jobs:
       - name: Verify contracts on Etherscan
         env:
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN_API_KEY }}
-          CHAIN_API_URL: ${{ secrets.ROPSTEN_ETH_HOSTNAME_HTTP }}
+          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
         run: |
           yarn run hardhat --network ${{ github.event.inputs.environment }} \
             etherscan-verify --license GPL-3.0 --force-license

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -113,29 +113,36 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Get upstream packages versions
-        uses: keep-network/ci/actions/upstream-builds-query@v1
-        id: upstream-builds-query
-        with:
-          upstream-builds: ${{ github.event.inputs.upstream_builds }}
-          query: keep-core-contracts-version = github.com/keep-network/keep-core/solidity-v1#version
+      # Ultimately, we want to get rid of steps deploying on Ropsten (as it will
+      # be shut down in Q4 2022) and switch to deployment on Goerli. We're
+      # leaving both deployment options for the transition period.
+      - name: Resolve latest contracts on Ropsten
+        if: github.event.inputs.environment == 'ropsten'
+        run: yarn upgrade @keep-network/keep-core@1.8.0-ropsten.16
 
-      - name: Resolve latest contracts
-        run: |
-          yarn upgrade \
-            @keep-network/keep-core@${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }}
+      - name: Resolve latest contracts on Goerli
+        if: github.event.inputs.environment == 'goerli'
+        run: yarn upgrade @keep-network/keep-core@1.8.1-goerli.0
 
       - name: Configure tenderly
-        if: github.event.inputs.environment == 'ropsten'
         env:
           TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
         run: ./config_tenderly.sh
 
-      - name: Deploy contracts
+      - name: Deploy contracts on Ropsten
+        if: github.event.inputs.environment == 'ropsten'
         env:
           CHAIN_API_URL: ${{ secrets.ROPSTEN_ETH_HOSTNAME_HTTP }}
           CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.ROPSTEN_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.ROPSTEN_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+        run: yarn deploy --network ${{ github.event.inputs.environment }}
+      
+      - name: Deploy contracts on Goerli
+        if: github.event.inputs.environment == 'goerli'
+        env:
+          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 
       - name: Bump up package version
@@ -149,10 +156,13 @@ jobs:
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }}
+        # TODO: remove `--dry-run` before merge to main
+        run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }} --dry-run
 
+      # TODO: restore commented out `uses` config before merge to `main``
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@v1
+        # uses: keep-network/ci/actions/notify-workflow-completed@v1
+        uses: keep-network/ci/actions/notify-workflow-completed@ci-goerli
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -114,7 +114,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Resolve latest contracts
-        run: yarn upgrade @keep-network/keep-core@1.8.1-goerli.0
+        run: yarn upgrade @keep-network/keep-core@${{ github.event.inputs.environment }}
 
       - name: Configure tenderly
         env:

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -99,7 +99,7 @@ jobs:
 
   contracts-deployment-testnet:
     needs: [contracts-build-and-test]
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'goerli'
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -44,19 +44,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14.x"
-          cache: "yarn"
+      # TODO: uncomment below block of code before merge to main
+      # - uses: actions/setup-node@v2
+      #   with:
+      #     node-version: "14.x"
+      #     cache: "yarn"
 
-      - name: Install dependencies
-        run: yarn install
+      # - name: Install dependencies
+      #   run: yarn install
 
-      - name: Build contracts
-        run: yarn build
+      # - name: Build contracts
+      #   run: yarn build
 
-      - name: Run tests
-        run: yarn test
+      # - name: Run tests
+      #   run: yarn test
 
   contracts-system-tests:
     needs: contracts-detect-changes
@@ -104,48 +105,49 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: "14.x"
-          cache: "yarn"
-          registry-url: "https://registry.npmjs.org"
+      # TODO: uncomment below block of code before merge to main
+      # - uses: actions/setup-node@v2
+      #   with:
+      #     node-version: "14.x"
+      #     cache: "yarn"
+      #     registry-url: "https://registry.npmjs.org"
 
-      - name: Install dependencies
-        run: yarn install --frozen-lockfile
+      # - name: Install dependencies
+      #   run: yarn install --frozen-lockfile
 
-      - name: Resolve latest contracts
-        run: yarn upgrade @keep-network/keep-core@1.8.1-goerli.0
+      # - name: Resolve latest contracts
+      #   run: yarn upgrade @keep-network/keep-core@1.8.1-goerli.0
 
-      - name: Configure tenderly
-        env:
-          TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
-        run: ./config_tenderly.sh
+      # - name: Configure tenderly
+      #   env:
+      #     TENDERLY_TOKEN: ${{ secrets.TENDERLY_TOKEN }}
+      #   run: ./config_tenderly.sh
 
-      - name: Deploy contracts
-        env:
-          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-        run: yarn deploy --network ${{ github.event.inputs.environment }}
+      # - name: Deploy contracts
+      #   env:
+      #     CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+      #     CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+      #     KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+      #   run: yarn deploy --network ${{ github.event.inputs.environment }}
 
-      - name: Bump up package version
-        id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
-        with:
-          environment: ${{ github.event.inputs.environment }}
-          branch: ${{ github.ref }}
-          commit: ${{ github.sha }}
+      # - name: Bump up package version
+      #   id: npm-version-bump
+      #   uses: keep-network/npm-version-bump@v2
+      #   with:
+      #     environment: ${{ github.event.inputs.environment }}
+      #     branch: ${{ github.ref }}
+      #     commit: ${{ github.sha }}
 
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        # TODO: remove `--dry-run` before merge to main
-        run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }} --dry-run
+      # - name: Publish to npm
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      #   # TODO: remove `--dry-run` before merge to main
+      #   run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }} --dry-run
 
       # TODO: restore commented out `uses` config before merge to `main``
       - name: Notify CI about completion of the workflow
         # uses: keep-network/ci/actions/notify-workflow-completed@v1
-        uses: keep-network/ci/actions/notify-workflow-completed@ci-goerli
+        uses: keep-network/ci/actions/notify-workflow-completed@main
         continue-on-error: true # TODO: remove before merge to main
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}


### PR DESCRIPTION
Görli became a recommended test network after Ropsten's deprecation
notice (https://blog.ethereum.org/2022/06/21/testnet-deprecation/).
We're modifying GitHub Actions workflow for deploying contracts to
support the deployment on Görli. We're also leaving the possibility of
deployment on Ropsten (this will be removed once we have the Görli
deployment battle-tested and Ropsten gets shut down).
We also change the way we handle `keep-core` dependency - in V2 of our
system we'll no longer planning to publish new `keep-core` packages -
hence we hardcode used version of the package for given testnet.

TODO:

- [x] Configure `GOERLI_ETH_HOSTNAME_HTTP `, `GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY`, `GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY`, `TENDERLY_TOKEN` GitHub secrets (@nkuba - could you do that? It would be also good to make similar ROPSTEN/GOERLI distinction in the secrets in the `keep-network` org)
- [x] Configure `CI_GITHUB_TOKEN` GitHub secret (@nkuba)
- [x] Verify the workflow once new V2-compatible config in `keep-core/ci` is ready
- [x] Remove testing configuration from the workflow

Refs:
https://github.com/keep-network/keep-core/issues/3012
https://github.com/keep-network/keep-core/pull/3081
https://github.com/keep-network/tbtc-v2/pull/382