### PR TITLE
Update range for @keep-network/keep-core dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,12 +59,12 @@
     "typescript": "^4.4.4"
   },
   "dependencies": {
-    "@keep-network/keep-core": ">1.8.1-dev <1.8.1-pre",
+    "@keep-network/keep-core": ">1.8.1-dev <1.8.1-goerli",
     "@openzeppelin/contracts": "~4.5.0",
     "@openzeppelin/contracts-upgradeable": "~4.5.2",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
   },
   "peerDependencies": {
-    "@keep-network/keep-core": ">1.8.1-dev <1.8.1-pre"
+    "@keep-network/keep-core": ">1.8.1-dev <1.8.1-goerli"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -569,7 +569,7 @@
   resolved "https://registry.yarnpkg.com/@keep-network/hardhat-helpers/-/hardhat-helpers-0.6.0-pre.8.tgz#6e0722889a0132dabed5182fb32f6424ff4a77d0"
   integrity sha512-51oLHceBubutBYxfVk2pLjgyhvpcDC1ahKM3V9lOiTa9lbWyY18Dza7rnM9V04kq+8DbweQRM0M9/f+K26nl9g==
 
-"@keep-network/keep-core@>1.8.1-dev <1.8.1-pre":
+"@keep-network/keep-core@>1.8.1-dev <1.8.1-goerli":
   version "1.8.1-dev.0"
   resolved "https://registry.yarnpkg.com/@keep-network/keep-core/-/keep-core-1.8.1-dev.0.tgz#d95864b25800214de43d8840376a68336cb12055"
   integrity sha512-gFXkgN4PYOYCZ14AskL7fZHEFW5mu3BDd+TJKBuKZc1q9CgRMOK+dxpJnSctxmSH1tV+Ln9v9yqlSkfPCoiBHw==


### PR DESCRIPTION
The range has to be updated as there are `goerli` packages published
now, that changes the alphabetical order.