### PR TITLE
Use upgrade --exact for NPM package publication

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -26,7 +26,8 @@ jobs:
 
       - name: Resolve latest contracts
         run: |
-          yarn upgrade @keep-network/keep-core
+          yarn upgrade --exact \
+            @keep-network/keep-core
 
       # Deploy contracts to a local network to generate deployment artifacts that
       # are required by dashboard compilation.


### PR DESCRIPTION
We want to add `--exact` flag so the version of tagged package is
resolved to an exact value. Without this flag by default the version is
resolved by adding `^`, which can cause problems when resolving versions
with `-dev`, `-goerli`, `-mainnet` suffixes.