### PR TITLE
Add job deploying contracts from `dapp-development` branch

### DIFF
--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -7,10 +7,24 @@ on:
     branches:
       - main
   pull_request:
+  # We intend to use `workflow dispatch` in two different situations/paths:
+  # 1. If a workflow will be manually dspatched from branch named
+  #    `dapp-development`, workflow will deploy the contracts on the selected
+  #    testnet and publish them to NPM registry with `dappdev<environment>`
+  #    suffix and `dapp-development-<environment>` tag. Such packages are meant
+  #    to be used locally by the team developing Threshold Token dApp and may
+  #    contain contracts that have different values from the ones used on
+  #    mainnet.
+  # 2. If a workflow will be manually dspatched from a branch which name is not
+  #    `dapp-development`, the workflow will deploy the contracts on the
+  #    selected testnet and publish them to NPM registry with `<environment>`
+  #    suffix and tag. Such packages will be used later to deploy public
+  #    Threshold Token dApp on a testnet, with contracts resembling those used
+  #    on mainnet.
   workflow_dispatch:
     inputs:
       environment:
-        description: "Environment for workflow execution"
+        description: "Environment (network) for workflow execution, e.g. `goerli`"
         required: false
         default: "dev"
       upstream_builds:
@@ -56,11 +70,14 @@ jobs:
         run: yarn build
 
       - name: Run tests
+        if: github.ref != 'refs/heads/dapp-development'
         run: yarn test
 
   contracts-system-tests:
     needs: contracts-detect-changes
-    if: needs.contracts-detect-changes.outputs.system-tests == 'true'
+    if: |
+      needs.contracts-detect-changes.outputs.system-tests == 'true'
+        && github.ref != 'refs/heads/dapp-development'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -99,7 +116,10 @@ jobs:
 
   contracts-deployment-testnet:
     needs: [contracts-build-and-test]
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.environment == 'goerli'
+    if: |
+      github.event_name == 'workflow_dispatch'
+        && github.event.inputs.environment == 'goerli'
+        && github.ref != 'refs/heads/dapp-development'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -195,6 +215,67 @@ jobs:
         run: |
           yarn run hardhat --network ${{ github.event.inputs.environment }} \
             etherscan-verify --license GPL-3.0 --force-license
+
+  # This job is responsible for publishing packages from `dapp-development`
+  # branch, which are slightly modified to help with the process of testing some
+  # features on the Threshold Token dApp. The job starts only if workflow gets
+  # triggered by the `workflow_dispatch` event on the branch `dapp-development`.
+  contracts-dapp-development-deployment-testnet:
+    needs: [contracts-build-and-test]
+    if: |
+      github.event_name == 'workflow_dispatch'
+        && github.event.inputs.environment == 'goerli'
+        && github.ref == 'refs/heads/dapp-development'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14.x"
+          cache: "yarn"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Resolve latest contracts
+        run: yarn upgrade @keep-network/keep-core@${{ github.event.inputs.environment }}
+
+      - name: Deploy contracts
+        env:
+          CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+        run: yarn deploy --network ${{ github.event.inputs.environment }}
+
+      - name: Bump up package version
+        id: npm-version-bump
+        uses: keep-network/npm-version-bump@v2
+        with:
+          environment: dappdev${{ github.event.inputs.environment }}
+          branch: ${{ github.ref }}
+          commit: ${{ github.sha }}
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm publish --access=public \
+            --network=${{ github.event.inputs.environment }} \
+            --tag dapp-development-${{ github.event.inputs.environment }}
+
+      - name: Notify CI about completion of the workflow
+        uses: keep-network/ci/actions/notify-workflow-completed@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
+        with:
+          module: "github.com/threshold-network/solidity-contracts"
+          url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          environment: ${{ github.event.inputs.environment }}
+          upstream_builds: ${{ github.event.inputs.upstream_builds }}
+          upstream_ref: dapp-development
+          version: ${{ steps.npm-version-bump.outputs.version }}
 
   contracts-slither:
     runs-on: ubuntu-latest

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -41,7 +41,7 @@ jobs:
     outputs:
       system-tests: ${{ steps.filter.outputs.system-tests }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         if: github.event_name == 'pull_request'
 
       - uses: dorny/paths-filter@v2
@@ -56,9 +56,9 @@ jobs:
   contracts-build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -80,9 +80,9 @@ jobs:
         && github.ref != 'refs/heads/dapp-development'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -101,9 +101,9 @@ jobs:
   contracts-deployment-dry-run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -121,9 +121,9 @@ jobs:
         && github.ref != 'refs/heads/dapp-development'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -173,7 +173,7 @@ jobs:
           version: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Upload files needed for etherscan verification
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Artifacts for etherscan verifcation
           path: |
@@ -185,14 +185,14 @@ jobs:
     needs: [contracts-deployment-testnet]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Download files needed for etherscan verification
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: Artifacts for etherscan verifcation
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -226,9 +226,9 @@ jobs:
         && github.ref == 'refs/heads/dapp-development'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           cache: "yarn"
@@ -281,14 +281,14 @@ jobs:
       github.event_name != 'workflow_dispatch'
         && github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14"
           cache: "yarn"
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: 3.8.5
 

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -26,7 +26,6 @@ on:
       environment:
         description: "Environment (network) for workflow execution, e.g. `goerli`"
         required: false
-        default: "dev"
       upstream_builds:
         description: "Upstream builds"
         required: false

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -118,7 +118,6 @@ jobs:
     needs: [contracts-build-and-test]
     if: |
       github.event_name == 'workflow_dispatch'
-        && github.event.inputs.environment == 'goerli'
         && github.ref != 'refs/heads/dapp-development'
     runs-on: ubuntu-latest
     steps:
@@ -224,7 +223,6 @@ jobs:
     needs: [contracts-build-and-test]
     if: |
       github.event_name == 'workflow_dispatch'
-        && github.event.inputs.environment == 'goerli'
         && github.ref == 'refs/heads/dapp-development'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -10,7 +10,7 @@ on:
   # We intend to use `workflow dispatch` in two different situations/paths:
   # 1. If a workflow will be manually dspatched from branch named
   #    `dapp-development`, workflow will deploy the contracts on the selected
-  #    testnet and publish them to NPM registry with `dappdev<environment>`
+  #    testnet and publish them to NPM registry with `dapp-dev-<environment>`
   #    suffix and `dapp-development-<environment>` tag. Such packages are meant
   #    to be used locally by the team developing Threshold Token dApp and may
   #    contain contracts that have different values from the ones used on
@@ -250,7 +250,7 @@ jobs:
         id: npm-version-bump
         uses: keep-network/npm-version-bump@v2
         with:
-          environment: dappdev${{ github.event.inputs.environment }}
+          environment: dapp-dev-${{ github.event.inputs.environment }}
           branch: ${{ github.ref }}
           commit: ${{ github.sha }}
 

--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -243,7 +243,7 @@ jobs:
       - name: Deploy contracts
         env:
           CHAIN_API_URL: ${{ secrets.GOERLI_ETH_HOSTNAME_HTTP }}
-          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+          CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.DAPP_DEV_GOERLI_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
           KEEP_CONTRACT_OWNER_ACCOUNT_PRIVATE_KEY: ${{ secrets.GOERLI_KEEP_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
         run: yarn deploy --network ${{ github.event.inputs.environment }}
 

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -11,9 +11,9 @@ jobs:
   code-lint-and-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14"
           cache: "yarn"

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -16,9 +16,9 @@ jobs:
   npm-compile-publish-contracts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: "14.x"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
There are situations when team developing T Token Dashboard needs to
locally test some functionalities using modified contracts, for example
ones with shorter authorization decrease delay. We decided to create a
`dapp-development` branch in each of the upstream modules of
`threshold-network/token-dashboard` CI module, which would store the
code of these modified contracts. In this PR we create a
`contracts-dapp-development-deployment-testnet` job which deploys the
contracts, creates an NPM package (with `dappdev<environment>` suffix
an `dapp-development-<environment>` tag) and publishes it to the NPM
registry. At the end, the job also starts similar deployment for a
downstream module. The job gets triggered only as a result of
`workflow_dispath` event from a `dapp-development` branch. Currently
only `goerli` environment is supported. We don't run system and unit
tests for `dapp-development` branch, as the tests are not configured to
work with the modified contracts.
Generally, the goal of the changes is to have the full set of
dapp-development-friendly contracts deployed to the NPM registry, so
that the dApp developers could quickly use them by upgrading the
`token-dashboard` dependencies using `yarn upgrade
<package-name>@dapp-development-goerli`.
If the workflow gets dispatched from a different branch than
`dapp-development`, the deploy will behave as it used to, publishing
package with deployed unmodified contracts to the NPM registry under
`<environment>` tag.

TODO:

- [x] Modify the secret for the deployer account in the `contracts-dapp-development-deployment-testnet` job
- [x] Bump actions to latest versions
- [x] Test the workflow using combined code from #119 and #118 (`dapp-development` branch)

Refs:
https://github.com/threshold-network/token-dashboard/issues/136
https://github.com/keep-network/keep-core/pull/3121
https://github.com/keep-network/tbtc-v2/pull/392