### PR TITLE
Start indexing default nammed accounts from 1

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -117,14 +117,15 @@ const config: HardhatUserConfig = {
   },
   namedAccounts: {
     deployer: {
-      default: 0, // take the first account as deployer
+      default: 1, // take the first account as deployer
+      goerli: 0,
       // mainnet: "0x123694886DBf5Ac94DDA07135349534536D14cAf",
     },
     thresholdCouncil: {
       mainnet: "0x9F6e831c8F8939DC0C830C6e492e7cEf4f9C2F5f",
     },
     keepRegistryKeeper: {
-      default: 0, // same as the deployer
+      default: 1, // same as the deployer
       ropsten: "0x923C5Dbf353e99394A21Aa7B67F3327Ca111C67D",
       goerli: "0x68ad60CC5e8f3B7cC53beaB321cf0e6036962dBc",
     },


### PR DESCRIPTION
For unit tests we want to avoid using account `0` to better verify that
the account we use is actually we want to. So the deployer will be `1`,
not to be mixed with the default `0` that provider may use.

For goerli we want to use the address that is resolved from a private
key passed, and there will be just one account with index `0`.