### PR TITLE
Allow to stake an amount equal to the minimum stake

### DIFF
--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -283,7 +283,10 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
             createdAt == 0 && stakingProviderStruct.owner == address(0),
             "Provider is already in use"
         );
-        require(amount > minTStakeAmount, "Amount is less than minimum");
+        require(
+            amount > 0 && amount >= minTStakeAmount,
+            "Amount is less than minimum"
+        );
         stakingProviderStruct.owner = msg.sender;
         stakingProviderStruct.authorizer = authorizer;
         stakingProviderStruct.beneficiary = beneficiary;

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -335,6 +335,9 @@ describe("TokenStaking", () => {
         let blockTimestamp
 
         beforeEach(async () => {
+          await tokenStaking
+            .connect(deployer)
+            .setMinimumStakeAmount(initialStakerBalance)
           await tToken.connect(staker).approve(tokenStaking.address, amount)
           tx = await tokenStaking
             .connect(staker)


### PR DESCRIPTION
Change the staking pre-requisite from `amount > minStake` to `amount >= minStake` (Fixes #90)