### PR TITLE
Upgrade `hardhat-deploy` to latest version (`^0.11.15`)

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -88,8 +88,10 @@ const config: HardhatUserConfig = {
     username: "thesis",
     project: "thesis/threshold-network",
   },
-  etherscan: {
-    apiKey: process.env.ETHERSCAN_API_KEY,
+  verify: {
+    etherscan: {
+      apiKey: process.env.ETHERSCAN_API_KEY,
+    },
   },
   external: {
     contracts: [

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "ethers": "^5.5.3",
     "hardhat": "^2.8.3",
     "hardhat-contract-sizer": "^2.5.0",
-    "hardhat-deploy": "^0.9.27",
+    "hardhat-deploy": "^0.11.15",
     "hardhat-gas-reporter": "^1.0.6",
     "prettier": "^2.3.2",
     "prettier-plugin-sh": "^0.7.1",

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -5824,7 +5824,7 @@ describe("TokenStaking", () => {
               stakingProvider.address,
               expectedKeepAmount,
               createdAt,
-              Zero
+              undelegatedAt
             )
             expect(
               await keepStakingMock.tattletales(otherStaker.address)

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -5294,9 +5294,13 @@ describe("TokenStaking", () => {
         })
 
         it("should not call seize in Keep contract", async () => {
-          expect(
-            await keepStakingMock.getDelegationInfo(stakingProvider.address)
-          ).to.deep.equal([newKeepAmount, createdAt, Zero])
+          await assertDelegationInfo(
+            stakingProvider.address,
+            newKeepAmount,
+            createdAt,
+            Zero
+          )
+
           expect(
             await keepStakingMock.tattletales(otherStaker.address)
           ).to.equal(0)
@@ -5335,9 +5339,12 @@ describe("TokenStaking", () => {
         })
 
         it("should not call seize in Keep contract", async () => {
-          expect(
-            await keepStakingMock.getDelegationInfo(stakingProvider.address)
-          ).to.deep.equal([newKeepAmount, createdAt, Zero])
+          await assertDelegationInfo(
+            stakingProvider.address,
+            newKeepAmount,
+            createdAt,
+            Zero
+          )
           expect(
             await keepStakingMock.tattletales(otherStaker.address)
           ).to.equal(0)
@@ -5405,9 +5412,12 @@ describe("TokenStaking", () => {
         })
 
         it("should not call seize in Keep contract", async () => {
-          expect(
-            await keepStakingMock.getDelegationInfo(stakingProvider.address)
-          ).to.deep.equal([Zero, createdAt, Zero])
+          await assertDelegationInfo(
+            stakingProvider.address,
+            Zero,
+            createdAt,
+            Zero
+          )
           expect(
             await keepStakingMock.tattletales(otherStaker.address)
           ).to.equal(0)
@@ -5549,9 +5559,12 @@ describe("TokenStaking", () => {
           })
 
           it("should call seize in Keep contract", async () => {
-            expect(
-              await keepStakingMock.getDelegationInfo(stakingProvider.address)
-            ).to.deep.equal([expectedKeepAmount, createdAt, Zero])
+            await assertDelegationInfo(
+              stakingProvider.address,
+              expectedKeepAmount,
+              createdAt,
+              Zero
+            )
             expect(
               await keepStakingMock.tattletales(otherStaker.address)
             ).to.equal(expectedReward)
@@ -5665,9 +5678,12 @@ describe("TokenStaking", () => {
           })
 
           it("should call seize in Keep contract", async () => {
-            expect(
-              await keepStakingMock.getDelegationInfo(stakingProvider.address)
-            ).to.deep.equal([expectedKeepAmount, createdAt, Zero])
+            await assertDelegationInfo(
+              stakingProvider.address,
+              expectedKeepAmount,
+              createdAt,
+              Zero
+            )
             expect(
               await keepStakingMock.tattletales(otherStaker.address)
             ).to.equal(expectedReward)
@@ -5804,9 +5820,12 @@ describe("TokenStaking", () => {
           })
 
           it("should call seize in Keep contract", async () => {
-            expect(
-              await keepStakingMock.getDelegationInfo(stakingProvider.address)
-            ).to.deep.equal([expectedKeepAmount, createdAt, undelegatedAt])
+            await assertDelegationInfo(
+              stakingProvider.address,
+              expectedKeepAmount,
+              createdAt,
+              Zero
+            )
             expect(
               await keepStakingMock.tattletales(otherStaker.address)
             ).to.equal(expectedReward)
@@ -7026,12 +7045,13 @@ describe("TokenStaking", () => {
         })
 
         it("should not call seize in Keep contract", async () => {
-          expect(
-            await keepStakingMock.getDelegationInfo(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero, Zero])
-          expect(
-            await keepStakingMock.getDelegationInfo(otherStaker.address)
-          ).to.deep.equal([keepAmount, createdAt, Zero])
+          await assertDelegationInfo(stakingProvider.address, Zero, Zero, Zero)
+          await assertDelegationInfo(
+            otherStaker.address,
+            keepAmount,
+            createdAt,
+            Zero
+          )
           expect(
             await keepStakingMock.tattletales(auxiliaryAccount.address)
           ).to.equal(0)
@@ -7172,9 +7192,7 @@ describe("TokenStaking", () => {
 
         it("should call seize in Keep contract", async () => {
           const expectedKeepReward = rewardFromPenalty(keepAmount.div(2), 100)
-          expect(
-            await keepStakingMock.getDelegationInfo(otherStaker.address)
-          ).to.deep.equal([Zero, createdAt, Zero])
+          await assertDelegationInfo(otherStaker.address, Zero, createdAt, Zero)
           expect(
             await keepStakingMock.tattletales(auxiliaryAccount.address)
           ).to.equal(expectedKeepReward)
@@ -7603,5 +7621,29 @@ describe("TokenStaking", () => {
         .deauthorizingTo,
       "invalid deauthorizingTo"
     ).to.equal(expectedDeauthorizingTo)
+  }
+
+  async function assertDelegationInfo(
+    stakingProviderAddress,
+    expectedAmount,
+    expectedCreatedAt,
+    expectedUndelegatedAt
+  ) {
+    expect(
+      (await keepStakingMock.getDelegationInfo(stakingProviderAddress)).amount,
+      "invalid amount"
+    ).to.equal(expectedAmount)
+
+    expect(
+      (await keepStakingMock.getDelegationInfo(stakingProviderAddress))
+        .createdAt,
+      "invalid createdAt"
+    ).to.equal(expectedCreatedAt)
+
+    expect(
+      (await keepStakingMock.getDelegationInfo(stakingProviderAddress))
+        .undelegatedAt,
+      "invalid undelegatedAt"
+    ).to.equal(expectedUndelegatedAt)
   }
 })

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -786,9 +786,7 @@ describe("TokenStaking", () => {
       })
 
       it("should do callback to NuCypher staking contract", async () => {
-        expect(await nucypherStakingMock.stakers(staker.address)).to.deep.equal(
-          [nuAmount, stakingProvider.address]
-        )
+        await assertNuStakers(staker.address, nuAmount, stakingProvider.address)
       })
 
       it("should increase available amount to authorize", async () => {
@@ -3742,9 +3740,7 @@ describe("TokenStaking", () => {
       })
 
       it("should do callback to NuCypher staking contract", async () => {
-        expect(await nucypherStakingMock.stakers(staker.address)).to.deep.equal(
-          [nuAmount, stakingProvider.address]
-        )
+        await assertNuStakers(staker.address, nuAmount, stakingProvider.address)
       })
 
       it("should emit ToppedUp event", async () => {
@@ -5941,9 +5937,12 @@ describe("TokenStaking", () => {
         })
 
         it("should not call seize in NuCypher contract", async () => {
-          expect(
-            await nucypherStakingMock.stakers(staker.address)
-          ).to.deep.equal([newNuAmount, stakingProvider.address])
+          await assertNuStakers(
+            staker.address,
+            newNuAmount,
+            stakingProvider.address
+          )
+
           expect(
             await nucypherStakingMock.investigators(otherStaker.address)
           ).to.equal(0)
@@ -5980,9 +5979,11 @@ describe("TokenStaking", () => {
         })
 
         it("should not call seize in NuCypher contract", async () => {
-          expect(
-            await nucypherStakingMock.stakers(staker.address)
-          ).to.deep.equal([newNuAmount, stakingProvider.address])
+          await assertNuStakers(
+            staker.address,
+            newNuAmount,
+            stakingProvider.address
+          )
           expect(
             await nucypherStakingMock.investigators(otherStaker.address)
           ).to.equal(0)
@@ -6050,9 +6051,7 @@ describe("TokenStaking", () => {
         })
 
         it("should not call seize in NuCypher contract", async () => {
-          expect(
-            await nucypherStakingMock.stakers(staker.address)
-          ).to.deep.equal([Zero, stakingProvider.address])
+          await assertNuStakers(staker.address, Zero, stakingProvider.address)
           expect(
             await nucypherStakingMock.investigators(otherStaker.address)
           ).to.equal(0)
@@ -6107,9 +6106,11 @@ describe("TokenStaking", () => {
         })
 
         it("should call seize in NuCypher contract", async () => {
-          expect(
-            await nucypherStakingMock.stakers(staker.address)
-          ).to.deep.equal([expectedNuAmount, stakingProvider.address])
+          await assertNuStakers(
+            staker.address,
+            expectedNuAmount,
+            stakingProvider.address
+          )
           expect(
             await nucypherStakingMock.investigators(otherStaker.address)
           ).to.equal(expectedReward)
@@ -6152,9 +6153,11 @@ describe("TokenStaking", () => {
         })
 
         it("should call seize in NuCypher contract", async () => {
-          expect(
-            await nucypherStakingMock.stakers(staker.address)
-          ).to.deep.equal([expectedNuAmount, stakingProvider.address])
+          await assertNuStakers(
+            staker.address,
+            expectedNuAmount,
+            stakingProvider.address
+          )
           expect(
             await nucypherStakingMock.investigators(otherStaker.address)
           ).to.equal(expectedReward)
@@ -6991,12 +6994,12 @@ describe("TokenStaking", () => {
         })
 
         it("should not call seize in NuCypher contract", async () => {
-          expect(
-            await nucypherStakingMock.stakers(staker.address)
-          ).to.deep.equal([Zero, AddressZero])
-          expect(
-            await nucypherStakingMock.stakers(otherStaker.address)
-          ).to.deep.equal([nuAmount, otherStaker.address])
+          await assertNuStakers(staker.address, Zero, AddressZero)
+          await assertNuStakers(
+            otherStaker.address,
+            nuAmount,
+            otherStaker.address
+          )
           expect(
             await nucypherStakingMock.investigators(auxiliaryAccount.address)
           ).to.equal(0)
@@ -7123,9 +7126,7 @@ describe("TokenStaking", () => {
 
         it("should call seize in NuCypher contract", async () => {
           const expectedNuReward = rewardFromPenalty(nuAmount, 100)
-          expect(
-            await nucypherStakingMock.stakers(otherStaker.address)
-          ).to.deep.equal([Zero, otherStaker.address])
+          await assertNuStakers(otherStaker.address, Zero, otherStaker.address)
           expect(
             await nucypherStakingMock.investigators(auxiliaryAccount.address)
           ).to.equal(expectedNuReward)
@@ -7505,5 +7506,21 @@ describe("TokenStaking", () => {
       (await tokenStaking.stakes(address)).nuInTStake,
       "invalid nuInTStake"
     ).to.equal(expectedNuInTStake)
+  }
+
+  async function assertNuStakers(
+    stakerAddress,
+    expectedValue,
+    expectedStakingProvider
+  ) {
+    expect(
+      (await nucypherStakingMock.stakers(stakerAddress)).value,
+      "invalid value"
+    ).to.equal(expectedValue)
+
+    expect(
+      (await nucypherStakingMock.stakers(stakerAddress)).stakingProvider,
+      "invalid stakingProvider"
+    ).to.equal(expectedStakingProvider)
   }
 })

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -1302,9 +1302,12 @@ describe("TokenStaking", () => {
             })
 
             it("should inform application", async () => {
-              expect(
-                await application1Mock.stakingProviders(stakingProvider.address)
-              ).to.deep.equal([authorizedAmount, Zero])
+              await assertApplicationStakingProviders(
+                application1Mock,
+                stakingProvider.address,
+                authorizedAmount,
+                Zero
+              )
             })
 
             it("should emit AuthorizationIncreased", async () => {
@@ -1412,9 +1415,12 @@ describe("TokenStaking", () => {
             })
 
             it("should inform application", async () => {
-              expect(
-                await application1Mock.stakingProviders(stakingProvider.address)
-              ).to.deep.equal([amount, Zero])
+              await assertApplicationStakingProviders(
+                application1Mock,
+                stakingProvider.address,
+                amount,
+                Zero
+              )
             })
 
             it("should emit two AuthorizationIncreased", async () => {
@@ -1604,9 +1610,12 @@ describe("TokenStaking", () => {
           })
 
           it("should inform application", async () => {
-            expect(
-              await application1Mock.stakingProviders(stakingProvider.address)
-            ).to.deep.equal([authorizedAmount, Zero])
+            await assertApplicationStakingProviders(
+              application1Mock,
+              stakingProvider.address,
+              authorizedAmount,
+              Zero
+            )
           })
 
           it("should emit AuthorizationIncreased", async () => {
@@ -1689,9 +1698,12 @@ describe("TokenStaking", () => {
             })
 
             it("should inform second application", async () => {
-              expect(
-                await application2Mock.stakingProviders(stakingProvider.address)
-              ).to.deep.equal([tAmount, Zero])
+              await assertApplicationStakingProviders(
+                application2Mock,
+                stakingProvider.address,
+                tAmount,
+                Zero
+              )
             })
 
             it("should emit AuthorizationIncreased", async () => {
@@ -1864,9 +1876,12 @@ describe("TokenStaking", () => {
           })
 
           it("should send request to application", async () => {
-            expect(
-              await application1Mock.stakingProviders(stakingProvider.address)
-            ).to.deep.equal([amount, expectedToAmount])
+            await assertApplicationStakingProviders(
+              application1Mock,
+              stakingProvider.address,
+              amount,
+              expectedToAmount
+            )
           })
 
           it("should emit AuthorizationDecreaseRequested", async () => {
@@ -1920,12 +1935,18 @@ describe("TokenStaking", () => {
             })
 
             it("should send request to application", async () => {
-              expect(
-                await application1Mock.stakingProviders(stakingProvider.address)
-              ).to.deep.equal([amount, Zero])
-              expect(
-                await application2Mock.stakingProviders(stakingProvider.address)
-              ).to.deep.equal([amount, Zero])
+              await assertApplicationStakingProviders(
+                application1Mock,
+                stakingProvider.address,
+                amount,
+                Zero
+              )
+              await assertApplicationStakingProviders(
+                application2Mock,
+                stakingProvider.address,
+                amount,
+                Zero
+              )
             })
 
             it("should emit AuthorizationDecreaseRequested", async () => {
@@ -1985,9 +2006,12 @@ describe("TokenStaking", () => {
           })
 
           it("should send request to application with last amount", async () => {
-            expect(
-              await application1Mock.stakingProviders(stakingProvider.address)
-            ).to.deep.equal([amount, expectedToAmount2])
+            await assertApplicationStakingProviders(
+              application1Mock,
+              stakingProvider.address,
+              amount,
+              expectedToAmount2
+            )
           })
 
           it("should emit AuthorizationDecreaseRequested twice", async () => {
@@ -5390,9 +5414,12 @@ describe("TokenStaking", () => {
         })
 
         it("should inform application", async () => {
-          expect(
-            await application1Mock.stakingProviders(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero])
+          await assertApplicationStakingProviders(
+            application1Mock,
+            stakingProvider.address,
+            Zero,
+            Zero
+          )
         })
 
         it("should emit TokensSeized and AuthorizationInvoluntaryDecreased", async () => {
@@ -5531,12 +5558,18 @@ describe("TokenStaking", () => {
           })
 
           it("should inform only one application", async () => {
-            expect(
-              await application1Mock.stakingProviders(stakingProvider.address)
-            ).to.deep.equal([expectedAuthorizedAmount1, Zero])
-            expect(
-              await application2Mock.stakingProviders(stakingProvider.address)
-            ).to.deep.equal([expectedAuthorizedAmount2, Zero])
+            await assertApplicationStakingProviders(
+              application1Mock,
+              stakingProvider.address,
+              expectedAuthorizedAmount1,
+              Zero
+            )
+            await assertApplicationStakingProviders(
+              application2Mock,
+              stakingProvider.address,
+              expectedAuthorizedAmount2,
+              Zero
+            )
           })
 
           it("should emit TokensSeized and AuthorizationInvoluntaryDecreased", async () => {
@@ -5641,15 +5674,21 @@ describe("TokenStaking", () => {
           })
 
           it("should inform application", async () => {
-            expect(
-              await application1Mock.stakingProviders(stakingProvider.address)
-            ).to.deep.equal([tStake, Zero])
+            await assertApplicationStakingProviders(
+              application1Mock,
+              stakingProvider.address,
+              tStake,
+              Zero
+            )
             await application1Mock.approveAuthorizationDecrease(
               stakingProvider.address
             )
-            expect(
-              await application1Mock.stakingProviders(stakingProvider.address)
-            ).to.deep.equal([Zero, Zero])
+            await assertApplicationStakingProviders(
+              application1Mock,
+              stakingProvider.address,
+              Zero,
+              Zero
+            )
           })
 
           it("should emit TokensSeized and AuthorizationInvoluntaryDecreased", async () => {
@@ -5774,16 +5813,18 @@ describe("TokenStaking", () => {
           })
 
           it("should catch exceptions during application calls", async () => {
-            expect(
-              await brokenApplicationMock.stakingProviders(
-                stakingProvider.address
-              )
-            ).to.deep.equal([authorizedAmount, Zero])
-            expect(
-              await expensiveApplicationMock.stakingProviders(
-                stakingProvider.address
-              )
-            ).to.deep.equal([authorizedAmount, Zero])
+            await assertApplicationStakingProviders(
+              brokenApplicationMock,
+              stakingProvider.address,
+              authorizedAmount,
+              Zero
+            )
+            await assertApplicationStakingProviders(
+              expensiveApplicationMock,
+              stakingProvider.address,
+              authorizedAmount,
+              Zero
+            )
             await expect(
               brokenApplicationMock.approveAuthorizationDecrease(
                 stakingProvider.address
@@ -6058,9 +6099,12 @@ describe("TokenStaking", () => {
         })
 
         it("should inform application", async () => {
-          expect(
-            await application1Mock.stakingProviders(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero])
+          await assertApplicationStakingProviders(
+            application1Mock,
+            stakingProvider.address,
+            Zero,
+            Zero
+          )
         })
 
         it("should emit TokensSeized and AuthorizationInvoluntaryDecreased", async () => {
@@ -7050,18 +7094,30 @@ describe("TokenStaking", () => {
         })
 
         it("should inform all applications", async () => {
-          expect(
-            await application1Mock.stakingProviders(stakingProvider.address)
-          ).to.deep.equal([provider1Authorized1.sub(amountToSlash), Zero])
-          expect(
-            await application2Mock.stakingProviders(stakingProvider.address)
-          ).to.deep.equal([provider1Authorized2.sub(amountToSlash), Zero])
-          expect(
-            await application1Mock.stakingProviders(otherStaker.address)
-          ).to.deep.equal([provider2Authorized1, Zero])
-          expect(
-            await application2Mock.stakingProviders(otherStaker.address)
-          ).to.deep.equal([provider2Authorized2, Zero])
+          await assertApplicationStakingProviders(
+            application1Mock,
+            stakingProvider.address,
+            provider1Authorized1.sub(amountToSlash),
+            Zero
+          )
+          await assertApplicationStakingProviders(
+            application2Mock,
+            stakingProvider.address,
+            provider1Authorized2.sub(amountToSlash),
+            Zero
+          )
+          await assertApplicationStakingProviders(
+            application1Mock,
+            otherStaker.address,
+            provider2Authorized1,
+            Zero
+          )
+          await assertApplicationStakingProviders(
+            application2Mock,
+            otherStaker.address,
+            provider2Authorized2,
+            Zero
+          )
         })
 
         it("should emit TokensSeized and SlashingProcessed events", async () => {
@@ -7145,12 +7201,18 @@ describe("TokenStaking", () => {
               application2Mock.address
             )
           ).to.equal(0)
-          expect(
-            await application1Mock.stakingProviders(otherStaker.address)
-          ).to.deep.equal([Zero, Zero])
-          expect(
-            await application2Mock.stakingProviders(otherStaker.address)
-          ).to.deep.equal([Zero, Zero])
+          await assertApplicationStakingProviders(
+            application1Mock,
+            otherStaker.address,
+            Zero,
+            Zero
+          )
+          await assertApplicationStakingProviders(
+            application2Mock,
+            otherStaker.address,
+            Zero,
+            Zero
+          )
         })
 
         it("should allow to authorize more applications", async () => {
@@ -7522,5 +7584,24 @@ describe("TokenStaking", () => {
       (await nucypherStakingMock.stakers(stakerAddress)).stakingProvider,
       "invalid stakingProvider"
     ).to.equal(expectedStakingProvider)
+  }
+
+  async function assertApplicationStakingProviders(
+    applicationMock,
+    stakingProviderAddress,
+    expectedAuthorized,
+    expectedDeauthorizingTo
+  ) {
+    expect(
+      (await applicationMock.stakingProviders(stakingProviderAddress))
+        .authorized,
+      "invalid authorized"
+    ).to.equal(expectedAuthorized)
+
+    expect(
+      (await applicationMock.stakingProviders(stakingProviderAddress))
+        .deauthorizingTo,
+      "invalid deauthorizingTo"
+    ).to.equal(expectedDeauthorizingTo)
   }
 })

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -361,9 +361,7 @@ describe("TokenStaking", () => {
         })
 
         it("should set value of stakes", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([amount, Zero, Zero])
+          await assertStakes(stakingProvider.address, amount, Zero, Zero)
           expect(await tokenStaking.stakedNu(stakingProvider.address)).to.equal(
             0
           )
@@ -544,9 +542,7 @@ describe("TokenStaking", () => {
         })
 
         it("should set value of stakes", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, tAmount, Zero])
+          await assertStakes(stakingProvider.address, Zero, tAmount, Zero)
           expect(await tokenStaking.stakedNu(stakingProvider.address)).to.equal(
             0
           )
@@ -777,9 +773,7 @@ describe("TokenStaking", () => {
       })
 
       it("should set value of stakes", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([Zero, Zero, tAmount])
+        await assertStakes(stakingProvider.address, Zero, Zero, tAmount)
         expect(await tokenStaking.stakedNu(stakingProvider.address)).to.equal(
           nuAmount.sub(conversion.remainder)
         )
@@ -2771,9 +2765,7 @@ describe("TokenStaking", () => {
       })
 
       it("should update T staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([expectedAmount, Zero, Zero])
+        await assertStakes(stakingProvider.address, expectedAmount, Zero, Zero)
       })
 
       it("should not update roles", async () => {
@@ -2869,9 +2861,7 @@ describe("TokenStaking", () => {
       })
 
       it("should update T staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([amount, Zero, Zero])
+        await assertStakes(stakingProvider.address, amount, Zero, Zero)
       })
 
       it("should not update start staking timestamp", async () => {
@@ -2930,9 +2920,12 @@ describe("TokenStaking", () => {
       })
 
       it("should update only T staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([topUpAmount, keepInTAmount, Zero])
+        await assertStakes(
+          stakingProvider.address,
+          topUpAmount,
+          keepInTAmount,
+          Zero
+        )
       })
 
       it("should not update roles", async () => {
@@ -3016,9 +3009,12 @@ describe("TokenStaking", () => {
       })
 
       it("should update only T staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([topUpAmount, Zero, nuInTAmount])
+        await assertStakes(
+          stakingProvider.address,
+          topUpAmount,
+          Zero,
+          nuInTAmount
+        )
       })
 
       it("should not update roles", async () => {
@@ -3219,9 +3215,12 @@ describe("TokenStaking", () => {
       })
 
       it("should update only Keep staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([Zero, newKeepInTAmount, Zero])
+        await assertStakes(
+          stakingProvider.address,
+          Zero,
+          newKeepInTAmount,
+          Zero
+        )
       })
 
       it("should not update roles", async () => {
@@ -3324,9 +3323,7 @@ describe("TokenStaking", () => {
       })
 
       it("should update only Keep staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([Zero, keepInTAmount, Zero])
+        await assertStakes(stakingProvider.address, Zero, keepInTAmount, Zero)
       })
 
       it("should not update start staking timestamp", async () => {
@@ -3382,9 +3379,12 @@ describe("TokenStaking", () => {
       })
 
       it("should update only Keep staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([tAmount, keepInTAmount, Zero])
+        await assertStakes(
+          stakingProvider.address,
+          tAmount,
+          keepInTAmount,
+          Zero
+        )
       })
 
       it("should not update roles", async () => {
@@ -3451,9 +3451,12 @@ describe("TokenStaking", () => {
       })
 
       it("should update only Keep staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([Zero, keepInTAmount, nuInTAmount])
+        await assertStakes(
+          stakingProvider.address,
+          Zero,
+          keepInTAmount,
+          nuInTAmount
+        )
       })
 
       it("should not update roles", async () => {
@@ -3573,9 +3576,7 @@ describe("TokenStaking", () => {
       })
 
       it("should update only Nu staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([Zero, Zero, newNuInTAmount])
+        await assertStakes(stakingProvider.address, Zero, Zero, newNuInTAmount)
         expect(await tokenStaking.stakedNu(stakingProvider.address)).to.equal(
           newNuAmount
         )
@@ -3666,9 +3667,7 @@ describe("TokenStaking", () => {
       })
 
       it("should update only Nu staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([Zero, Zero, nuInTAmount])
+        await assertStakes(stakingProvider.address, Zero, Zero, nuInTAmount)
         expect(await tokenStaking.stakedNu(stakingProvider.address)).to.equal(
           nuAmount
         )
@@ -3712,9 +3711,7 @@ describe("TokenStaking", () => {
       })
 
       it("should update only Nu staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([tAmount, Zero, nuInTAmount])
+        await assertStakes(stakingProvider.address, tAmount, Zero, nuInTAmount)
         expect(await tokenStaking.stakedNu(stakingProvider.address)).to.equal(
           nuAmount.sub(conversion.remainder)
         )
@@ -3792,9 +3789,12 @@ describe("TokenStaking", () => {
       })
 
       it("should update only Nu staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([Zero, keepInTAmount, nuInTAmount])
+        await assertStakes(
+          stakingProvider.address,
+          Zero,
+          keepInTAmount,
+          nuInTAmount
+        )
         expect(await tokenStaking.stakedNu(stakingProvider.address)).to.equal(
           nuAmount.sub(conversion.remainder)
         )
@@ -4040,9 +4040,7 @@ describe("TokenStaking", () => {
       })
 
       it("should update T staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([Zero, Zero, Zero])
+        await assertStakes(stakingProvider.address, Zero, Zero, Zero)
       })
 
       it("should not update roles", async () => {
@@ -4278,9 +4276,7 @@ describe("TokenStaking", () => {
         })
 
         it("should set Keep staked amount to zero", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([tAmount, Zero, Zero])
+          await assertStakes(stakingProvider.address, tAmount, Zero, Zero)
         })
 
         it("should not update roles", async () => {
@@ -4592,9 +4588,12 @@ describe("TokenStaking", () => {
         })
 
         it("should update Nu staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([tAmount, Zero, expectedNuInTAmount])
+          await assertStakes(
+            stakingProvider.address,
+            tAmount,
+            Zero,
+            expectedNuInTAmount
+          )
           expect(await tokenStaking.stakedNu(stakingProvider.address)).to.equal(
             expectedNuAmount
           )
@@ -4710,9 +4709,12 @@ describe("TokenStaking", () => {
         })
 
         it("should update Nu staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero, expectedNuInTAmount])
+          await assertStakes(
+            stakingProvider.address,
+            Zero,
+            Zero,
+            expectedNuInTAmount
+          )
           expect(await tokenStaking.stakedNu(stakingProvider.address)).to.equal(
             expectedNuAmount
           )
@@ -4867,9 +4869,7 @@ describe("TokenStaking", () => {
       })
 
       it("should update staked amount", async () => {
-        expect(
-          await tokenStaking.stakes(stakingProvider.address)
-        ).to.deep.equal([Zero, Zero, Zero])
+        await assertStakes(stakingProvider.address, Zero, Zero, Zero)
       })
 
       it("should not update roles", async () => {
@@ -5256,9 +5256,12 @@ describe("TokenStaking", () => {
         })
 
         it("should update staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, newKeepInTAmount, Zero])
+          await assertStakes(
+            stakingProvider.address,
+            Zero,
+            newKeepInTAmount,
+            Zero
+          )
         })
 
         it("should decrease available amount to authorize", async () => {
@@ -5303,9 +5306,12 @@ describe("TokenStaking", () => {
         })
 
         it("should update staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, newKeepInTAmount, Zero])
+          await assertStakes(
+            stakingProvider.address,
+            Zero,
+            newKeepInTAmount,
+            Zero
+          )
         })
 
         it("should not call seize in Keep contract", async () => {
@@ -5345,9 +5351,7 @@ describe("TokenStaking", () => {
         })
 
         it("should update staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero, Zero])
+          await assertStakes(stakingProvider.address, Zero, Zero, Zero)
         })
 
         it("should decrease available amount to authorize", async () => {
@@ -5462,9 +5466,12 @@ describe("TokenStaking", () => {
           })
 
           it("should update staked amount", async () => {
-            expect(
-              await tokenStaking.stakes(stakingProvider.address)
-            ).to.deep.equal([Zero, expectedKeepInTAmount, Zero])
+            await assertStakes(
+              stakingProvider.address,
+              Zero,
+              expectedKeepInTAmount,
+              Zero
+            )
           })
 
           it("should decrease available amount to authorize", async () => {
@@ -5607,9 +5614,7 @@ describe("TokenStaking", () => {
           })
 
           it("should update staked amount", async () => {
-            expect(
-              await tokenStaking.stakes(stakingProvider.address)
-            ).to.deep.equal([tStake, Zero, Zero])
+            await assertStakes(stakingProvider.address, tStake, Zero, Zero)
           })
 
           it("should decrease available amount to authorize", async () => {
@@ -5745,9 +5750,7 @@ describe("TokenStaking", () => {
           })
 
           it("should update staked amount", async () => {
-            expect(
-              await tokenStaking.stakes(stakingProvider.address)
-            ).to.deep.equal([Zero, Zero, Zero])
+            await assertStakes(stakingProvider.address, Zero, Zero, Zero)
           })
 
           it("should decrease authorized amount for both applications", async () => {
@@ -5920,9 +5923,12 @@ describe("TokenStaking", () => {
         })
 
         it("should update staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero, newNuInTAmount])
+          await assertStakes(
+            stakingProvider.address,
+            Zero,
+            Zero,
+            newNuInTAmount
+          )
         })
 
         it("should decrease available amount to authorize", async () => {
@@ -5965,9 +5971,12 @@ describe("TokenStaking", () => {
         })
 
         it("should update staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero, newNuInTAmount])
+          await assertStakes(
+            stakingProvider.address,
+            Zero,
+            Zero,
+            newNuInTAmount
+          )
         })
 
         it("should not call seize in NuCypher contract", async () => {
@@ -6007,9 +6016,7 @@ describe("TokenStaking", () => {
         })
 
         it("should update staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero, Zero])
+          await assertStakes(stakingProvider.address, Zero, Zero, Zero)
         })
 
         it("should decrease available amount to authorize", async () => {
@@ -6091,9 +6098,12 @@ describe("TokenStaking", () => {
         })
 
         it("should update staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero, expectedNuInTAmount])
+          await assertStakes(
+            stakingProvider.address,
+            Zero,
+            Zero,
+            expectedNuInTAmount
+          )
         })
 
         it("should call seize in NuCypher contract", async () => {
@@ -6138,9 +6148,7 @@ describe("TokenStaking", () => {
         })
 
         it("should update staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero, Zero])
+          await assertStakes(stakingProvider.address, Zero, Zero, Zero)
         })
 
         it("should call seize in NuCypher contract", async () => {
@@ -6934,9 +6942,12 @@ describe("TokenStaking", () => {
         })
 
         it("should update staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([expectedAmount, Zero, Zero])
+          await assertStakes(
+            stakingProvider.address,
+            expectedAmount,
+            Zero,
+            Zero
+          )
         })
 
         it("should decrease the delegatee voting power", async () => {
@@ -7073,11 +7084,7 @@ describe("TokenStaking", () => {
         })
 
         it("should update staked amount", async () => {
-          expect(await tokenStaking.stakes(otherStaker.address)).to.deep.equal([
-            Zero,
-            Zero,
-            Zero,
-          ])
+          await assertStakes(otherStaker.address, Zero, Zero, Zero)
         })
 
         it("should update index of queue", async () => {
@@ -7225,9 +7232,7 @@ describe("TokenStaking", () => {
         })
 
         it("should not update staked amount", async () => {
-          expect(
-            await tokenStaking.stakes(stakingProvider.address)
-          ).to.deep.equal([Zero, Zero, Zero])
+          await assertStakes(stakingProvider.address, Zero, Zero, Zero)
         })
 
         it("should update index of queue", async () => {
@@ -7481,4 +7486,24 @@ describe("TokenStaking", () => {
       }
     )
   })
+
+  async function assertStakes(
+    address,
+    expectedTStake,
+    expectedKeepInTStake,
+    expectedNuInTStake
+  ) {
+    expect(
+      (await tokenStaking.stakes(address)).tStake,
+      "invalid tStake"
+    ).to.equal(expectedTStake)
+    expect(
+      (await tokenStaking.stakes(address)).keepInTStake,
+      "invalid keepInTStake"
+    ).to.equal(expectedKeepInTStake)
+    expect(
+      (await tokenStaking.stakes(address)).nuInTStake,
+      "invalid nuInTStake"
+    ).to.equal(expectedNuInTStake)
+  }
 })

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -6523,14 +6523,8 @@ describe("TokenStaking", () => {
       })
 
       it("should add two slashing events", async () => {
-        expect(await tokenStaking.slashingQueue(0)).to.deep.equal([
-          stakingProvider.address,
-          amount,
-        ])
-        expect(await tokenStaking.slashingQueue(1)).to.deep.equal([
-          otherStaker.address,
-          amountToSlash,
-        ])
+        await assertSlashingQueue(0, stakingProvider.address, amount)
+        await assertSlashingQueue(1, otherStaker.address, amountToSlash)
         expect(await tokenStaking.getSlashingQueueLength()).to.equal(2)
       })
     })
@@ -6587,14 +6581,8 @@ describe("TokenStaking", () => {
       })
 
       it("should add two slashing events", async () => {
-        expect(await tokenStaking.slashingQueue(0)).to.deep.equal([
-          stakingProvider.address,
-          amountToSlash,
-        ])
-        expect(await tokenStaking.slashingQueue(1)).to.deep.equal([
-          otherStaker.address,
-          amountToSlash,
-        ])
+        await assertSlashingQueue(0, stakingProvider.address, amountToSlash)
+        await assertSlashingQueue(1, otherStaker.address, amountToSlash)
         expect(await tokenStaking.getSlashingQueueLength()).to.equal(2)
       })
 
@@ -6668,14 +6656,8 @@ describe("TokenStaking", () => {
       })
 
       it("should add two slashing events", async () => {
-        expect(await tokenStaking.slashingQueue(0)).to.deep.equal([
-          otherStaker.address,
-          amountToSlash,
-        ])
-        expect(await tokenStaking.slashingQueue(1)).to.deep.equal([
-          stakingProvider.address,
-          amountToSlash,
-        ])
+        await assertSlashingQueue(0, otherStaker.address, amountToSlash)
+        await assertSlashingQueue(1, stakingProvider.address, amountToSlash)
         expect(await tokenStaking.getSlashingQueueLength()).to.equal(2)
       })
 
@@ -6707,10 +6689,7 @@ describe("TokenStaking", () => {
       })
 
       it("should add one slashing event", async () => {
-        expect(await tokenStaking.slashingQueue(0)).to.deep.equal([
-          stakingProvider.address,
-          amountToSlash,
-        ])
+        await assertSlashingQueue(0, stakingProvider.address, amountToSlash)
         expect(await tokenStaking.getSlashingQueueLength()).to.equal(1)
       })
 
@@ -6749,10 +6728,7 @@ describe("TokenStaking", () => {
       })
 
       it("should add one slashing event", async () => {
-        expect(await tokenStaking.slashingQueue(0)).to.deep.equal([
-          otherStaker.address,
-          amountToSlash,
-        ])
+        await assertSlashingQueue(0, otherStaker.address, amountToSlash)
       })
 
       it("should keep index of queue unchanged", async () => {
@@ -7645,5 +7621,20 @@ describe("TokenStaking", () => {
         .undelegatedAt,
       "invalid undelegatedAt"
     ).to.equal(expectedUndelegatedAt)
+  }
+
+  async function assertSlashingQueue(
+    index,
+    expectedStakingProviderAddress,
+    expectedAmount
+  ) {
+    expect(
+      (await tokenStaking.slashingQueue(index)).stakingProvider,
+      "invalid stakingProvider"
+    ).to.equal(expectedStakingProviderAddress)
+    expect(
+      (await tokenStaking.slashingQueue(index)).amount,
+      "invalid amount"
+    ).to.equal(expectedAmount)
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,7 +236,7 @@
     "@ethersproject/properties" ">=5.0.0-beta.131"
     "@ethersproject/strings" ">=5.0.0-beta.130"
 
-"@ethersproject/abi@5.5.0", "@ethersproject/abi@^5.0.0-beta.146", "@ethersproject/abi@^5.1.2", "@ethersproject/abi@^5.4.0", "@ethersproject/abi@^5.5.0":
+"@ethersproject/abi@5.5.0", "@ethersproject/abi@^5.0.0-beta.146", "@ethersproject/abi@^5.1.2":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.5.0.tgz#fb52820e22e50b854ff15ce1647cc508d6660613"
   integrity sha512-loW7I4AohP5KycATvc0MgujU6JyCHPqHdeoo9z3Nr9xEiNioxa65ccdm1+fsoJhkuhdRtfcL8cfyGamz2AxZ5w==
@@ -266,7 +266,22 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
 
-"@ethersproject/abstract-provider@5.5.1", "@ethersproject/abstract-provider@^5.5.0":
+"@ethersproject/abi@^5.5.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
+  integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/abstract-provider@5.5.1":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz#2f1f6e8a3ab7d378d8ad0b5718460f85649710c5"
   integrity sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==
@@ -292,7 +307,20 @@
     "@ethersproject/transactions" "^5.6.2"
     "@ethersproject/web" "^5.6.1"
 
-"@ethersproject/abstract-signer@5.5.0", "@ethersproject/abstract-signer@^5.4.1", "@ethersproject/abstract-signer@^5.5.0":
+"@ethersproject/abstract-provider@^5.5.0", "@ethersproject/abstract-provider@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
+  integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+
+"@ethersproject/abstract-signer@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz#590ff6693370c60ae376bf1c7ada59eb2a8dd08d"
   integrity sha512-lj//7r250MXVLKI7sVarXAbZXbv9P50lgmJQGr2/is82EwEb8r7HrxsmMqAjTsztMYy7ohrIhGMIml+Gx4D3mA==
@@ -314,7 +342,18 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
 
-"@ethersproject/address@5.5.0", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.4.0", "@ethersproject/address@^5.5.0":
+"@ethersproject/abstract-signer@^5.5.0", "@ethersproject/abstract-signer@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
+  integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/address@5.5.0", "@ethersproject/address@>=5.0.0-beta.128":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.5.0.tgz#bcc6f576a553f21f3dd7ba17248f81b473c9c78f"
   integrity sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==
@@ -336,7 +375,18 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/rlp" "^5.6.1"
 
-"@ethersproject/base64@5.5.0", "@ethersproject/base64@^5.5.0":
+"@ethersproject/address@^5.5.0", "@ethersproject/address@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
+  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+
+"@ethersproject/base64@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.5.0.tgz#881e8544e47ed976930836986e5eb8fab259c090"
   integrity sha512-tdayUKhU1ljrlHzEWbStXazDpsx4eg1dBXUSI6+mHlYklOXoXF6lZvw8tnD6oVaWfnMxAgRSKROg3cVKtCcppA==
@@ -350,7 +400,14 @@
   dependencies:
     "@ethersproject/bytes" "^5.6.1"
 
-"@ethersproject/basex@5.5.0", "@ethersproject/basex@^5.5.0":
+"@ethersproject/base64@^5.5.0", "@ethersproject/base64@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
+  integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+
+"@ethersproject/basex@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.5.0.tgz#e40a53ae6d6b09ab4d977bd037010d4bed21b4d3"
   integrity sha512-ZIodwhHpVJ0Y3hUCfUucmxKsWQA5TMnavp5j/UOuDdzZWzJlRmuOjcTMIGgHCYuZmHt36BfiSyQPSRskPxbfaQ==
@@ -366,7 +423,15 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/properties" "^5.6.0"
 
-"@ethersproject/bignumber@5.5.0", "@ethersproject/bignumber@>=5.0.0-beta.130", "@ethersproject/bignumber@^5.4.1", "@ethersproject/bignumber@^5.5.0":
+"@ethersproject/basex@^5.5.0", "@ethersproject/basex@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.7.0.tgz#97034dc7e8938a8ca943ab20f8a5e492ece4020b"
+  integrity sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+
+"@ethersproject/bignumber@5.5.0", "@ethersproject/bignumber@>=5.0.0-beta.130":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.5.0.tgz#875b143f04a216f4f8b96245bde942d42d279527"
   integrity sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==
@@ -384,7 +449,16 @@
     "@ethersproject/logger" "^5.6.0"
     bn.js "^5.2.1"
 
-"@ethersproject/bytes@5.5.0", "@ethersproject/bytes@>=5.0.0-beta.129", "@ethersproject/bytes@^5.4.0", "@ethersproject/bytes@^5.5.0":
+"@ethersproject/bignumber@^5.5.0", "@ethersproject/bignumber@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
+  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    bn.js "^5.2.1"
+
+"@ethersproject/bytes@5.5.0", "@ethersproject/bytes@>=5.0.0-beta.129":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
   integrity sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==
@@ -398,7 +472,14 @@
   dependencies:
     "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/constants@5.5.0", "@ethersproject/constants@>=5.0.0-beta.128", "@ethersproject/constants@^5.4.0", "@ethersproject/constants@^5.5.0":
+"@ethersproject/bytes@^5.5.0", "@ethersproject/bytes@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
+  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/constants@5.5.0", "@ethersproject/constants@>=5.0.0-beta.128":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.5.0.tgz#d2a2cd7d94bd1d58377d1d66c4f53c9be4d0a45e"
   integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
@@ -412,7 +493,14 @@
   dependencies:
     "@ethersproject/bignumber" "^5.6.2"
 
-"@ethersproject/contracts@5.5.0", "@ethersproject/contracts@^5.4.1":
+"@ethersproject/constants@^5.5.0", "@ethersproject/constants@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
+  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+
+"@ethersproject/contracts@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.5.0.tgz#b735260d4bd61283a670a82d5275e2a38892c197"
   integrity sha512-2viY7NzyvJkh+Ug17v7g3/IJC8HqZBDcOjYARZLdzRxrfGlRgmYgl6xPRKVbEzy1dWKw/iv7chDcS83pg6cLxg==
@@ -444,7 +532,7 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/transactions" "^5.6.2"
 
-"@ethersproject/hash@5.5.0", "@ethersproject/hash@>=5.0.0-beta.128", "@ethersproject/hash@^5.5.0":
+"@ethersproject/hash@5.5.0", "@ethersproject/hash@>=5.0.0-beta.128":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.5.0.tgz#7cee76d08f88d1873574c849e0207dcb32380cc9"
   integrity sha512-dnGVpK1WtBjmnp3mUT0PlU2MpapnwWI0PibldQEq1408tQBAbZpPidkWoVVuNMOl/lISO3+4hXZWCL3YV7qzfg==
@@ -472,7 +560,22 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
 
-"@ethersproject/hdnode@5.5.0", "@ethersproject/hdnode@^5.5.0":
+"@ethersproject/hash@^5.5.0", "@ethersproject/hash@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
+  integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/hdnode@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.5.0.tgz#4a04e28f41c546f7c978528ea1575206a200ddf6"
   integrity sha512-mcSOo9zeUg1L0CoJH7zmxwUG5ggQHU1UrRf8jyTYy6HxdZV+r0PBoL1bxr+JHIPXRzS6u/UW4mEn43y0tmyF8Q==
@@ -508,7 +611,25 @@
     "@ethersproject/transactions" "^5.6.2"
     "@ethersproject/wordlists" "^5.6.1"
 
-"@ethersproject/json-wallets@5.5.0", "@ethersproject/json-wallets@^5.5.0":
+"@ethersproject/hdnode@^5.5.0", "@ethersproject/hdnode@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hdnode/-/hdnode-5.7.0.tgz#e627ddc6b466bc77aebf1a6b9e47405ca5aef9cf"
+  integrity sha512-OmyYo9EENBPPf4ERhR7oj6uAtUAhYGqOnIS+jE5pTXvdKBS99ikzq1E7Iv0ZQZ5V36Lqx1qZLeak0Ra16qpeOg==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/pbkdf2" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/wordlists" "^5.7.0"
+
+"@ethersproject/json-wallets@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.5.0.tgz#dd522d4297e15bccc8e1427d247ec8376b60e325"
   integrity sha512-9lA21XQnCdcS72xlBn1jfQdj2A1VUxZzOzi9UkNdnokNKke/9Ya2xA9aIK1SC3PQyBDLt4C+dfps7ULpkvKikQ==
@@ -546,7 +667,26 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
-"@ethersproject/keccak256@5.5.0", "@ethersproject/keccak256@>=5.0.0-beta.127", "@ethersproject/keccak256@^5.5.0":
+"@ethersproject/json-wallets@^5.5.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/json-wallets/-/json-wallets-5.7.0.tgz#5e3355287b548c32b368d91014919ebebddd5360"
+  integrity sha512-8oee5Xgu6+RKgJTkvEMl2wDgSPSAQ9MB/3JYjFV9jlKvcYHUXZC+cQp0njgmxdHkYWn8s6/IqIZYm0YWCjO/0g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hdnode" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/pbkdf2" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    aes-js "3.0.0"
+    scrypt-js "3.0.1"
+
+"@ethersproject/keccak256@5.5.0", "@ethersproject/keccak256@>=5.0.0-beta.127":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.5.0.tgz#e4b1f9d7701da87c564ffe336f86dcee82983492"
   integrity sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==
@@ -562,7 +702,15 @@
     "@ethersproject/bytes" "^5.6.1"
     js-sha3 "0.8.0"
 
-"@ethersproject/logger@5.5.0", "@ethersproject/logger@>=5.0.0-beta.129", "@ethersproject/logger@^5.5.0":
+"@ethersproject/keccak256@^5.5.0", "@ethersproject/keccak256@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
+  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    js-sha3 "0.8.0"
+
+"@ethersproject/logger@5.5.0", "@ethersproject/logger@>=5.0.0-beta.129":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
   integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
@@ -572,7 +720,12 @@
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.6.0.tgz#d7db1bfcc22fd2e4ab574cba0bb6ad779a9a3e7a"
   integrity sha512-BiBWllUROH9w+P21RzoxJKzqoqpkyM1pRnEKG69bulE9TSQD8SAIvTQqIMZmmCO8pUNkgLP1wndX1gKghSpBmg==
 
-"@ethersproject/networks@5.5.2", "@ethersproject/networks@^5.5.0":
+"@ethersproject/logger@^5.5.0", "@ethersproject/logger@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
+  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
+
+"@ethersproject/networks@5.5.2":
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.5.2.tgz#784c8b1283cd2a931114ab428dae1bd00c07630b"
   integrity sha512-NEqPxbGBfy6O3x4ZTISb90SjEDkWYDUbEeIFhJly0F7sZjoQMnj5KYzMSkMkLKZ+1fGpx00EDpHQCy6PrDupkQ==
@@ -586,7 +739,14 @@
   dependencies:
     "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/pbkdf2@5.5.0", "@ethersproject/pbkdf2@^5.5.0":
+"@ethersproject/networks@^5.5.0", "@ethersproject/networks@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
+  integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/pbkdf2@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.5.0.tgz#e25032cdf02f31505d47afbf9c3e000d95c4a050"
   integrity sha512-SaDvQFvXPnz1QGpzr6/HToLifftSXGoXrbpZ6BvoZhmx4bNLHrxDe8MZisuecyOziP1aVEwzC2Hasj+86TgWVg==
@@ -602,7 +762,15 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/sha2" "^5.6.1"
 
-"@ethersproject/properties@5.5.0", "@ethersproject/properties@>=5.0.0-beta.131", "@ethersproject/properties@^5.5.0":
+"@ethersproject/pbkdf2@^5.5.0", "@ethersproject/pbkdf2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/pbkdf2/-/pbkdf2-5.7.0.tgz#d2267d0a1f6e123f3771007338c47cccd83d3102"
+  integrity sha512-oR/dBRZR6GTyaofd86DehG72hY6NpAjhabkhxgr3X2FpJtJuodEl2auADWBZfhDHgVCbu3/H/Ocq2uC6dpNjjw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+
+"@ethersproject/properties@5.5.0", "@ethersproject/properties@>=5.0.0-beta.131":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.5.0.tgz#61f00f2bb83376d2071baab02245f92070c59995"
   integrity sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==
@@ -616,7 +784,14 @@
   dependencies:
     "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/providers@5.5.3", "@ethersproject/providers@^5.4.4":
+"@ethersproject/properties@^5.5.0", "@ethersproject/properties@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
+  integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/providers@5.5.3":
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.3.tgz#56c2b070542ac44eb5de2ed3cf6784acd60a3130"
   integrity sha512-ZHXxXXXWHuwCQKrgdpIkbzMNJMvs+9YWemanwp1fA7XZEv7QlilseysPvQe0D7Q7DlkJX/w/bGA1MdgK2TbGvA==
@@ -667,7 +842,7 @@
     bech32 "1.1.4"
     ws "7.4.6"
 
-"@ethersproject/random@5.5.1", "@ethersproject/random@^5.5.0":
+"@ethersproject/random@5.5.1":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.5.1.tgz#7cdf38ea93dc0b1ed1d8e480ccdaf3535c555415"
   integrity sha512-YaU2dQ7DuhL5Au7KbcQLHxcRHfgyNgvFV4sQOo0HrtW3Zkrc9ctWNz8wXQ4uCSfSDsqX2vcjhroxU5RQRV0nqA==
@@ -683,7 +858,15 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/rlp@5.5.0", "@ethersproject/rlp@^5.5.0":
+"@ethersproject/random@^5.5.0", "@ethersproject/random@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
+  integrity sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/rlp@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.5.0.tgz#530f4f608f9ca9d4f89c24ab95db58ab56ab99a0"
   integrity sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==
@@ -699,7 +882,15 @@
     "@ethersproject/bytes" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/sha2@5.5.0", "@ethersproject/sha2@^5.5.0":
+"@ethersproject/rlp@^5.5.0", "@ethersproject/rlp@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
+  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/sha2@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.5.0.tgz#a40a054c61f98fd9eee99af2c3cc6ff57ec24db7"
   integrity sha512-B5UBoglbCiHamRVPLA110J+2uqsifpZaTmid2/7W5rbtYVz6gus6/hSDieIU/6gaKIDcOj12WnOdiymEUHIAOA==
@@ -717,7 +908,16 @@
     "@ethersproject/logger" "^5.6.0"
     hash.js "1.1.7"
 
-"@ethersproject/signing-key@5.5.0", "@ethersproject/signing-key@^5.5.0":
+"@ethersproject/sha2@^5.5.0", "@ethersproject/sha2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
+  integrity sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.5.0.tgz#2aa37169ce7e01e3e80f2c14325f624c29cedbe0"
   integrity sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==
@@ -741,7 +941,19 @@
     elliptic "6.5.4"
     hash.js "1.1.7"
 
-"@ethersproject/solidity@5.5.0", "@ethersproject/solidity@^5.4.0":
+"@ethersproject/signing-key@^5.5.0", "@ethersproject/signing-key@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
+  integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    bn.js "^5.2.1"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/solidity@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/solidity/-/solidity-5.5.0.tgz#2662eb3e5da471b85a20531e420054278362f93f"
   integrity sha512-9NgZs9LhGMj6aCtHXhtmFQ4AN4sth5HuFXVvAQtzmm0jpSCNOTGtrHZJAeYTh7MBjRR8brylWZxBZR9zDStXbw==
@@ -765,7 +977,7 @@
     "@ethersproject/sha2" "^5.6.1"
     "@ethersproject/strings" "^5.6.1"
 
-"@ethersproject/strings@5.5.0", "@ethersproject/strings@>=5.0.0-beta.130", "@ethersproject/strings@^5.5.0":
+"@ethersproject/strings@5.5.0", "@ethersproject/strings@>=5.0.0-beta.130":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.5.0.tgz#e6784d00ec6c57710755699003bc747e98c5d549"
   integrity sha512-9fy3TtF5LrX/wTrBaT8FGE6TDJyVjOvXynXJz5MT5azq+E6D92zuKNx7i29sWW2FjVOaWjAsiZ1ZWznuduTIIQ==
@@ -783,7 +995,16 @@
     "@ethersproject/constants" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/transactions@5.5.0", "@ethersproject/transactions@^5.0.0-beta.135", "@ethersproject/transactions@^5.4.0", "@ethersproject/transactions@^5.5.0":
+"@ethersproject/strings@^5.5.0", "@ethersproject/strings@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
+  integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/transactions@5.5.0", "@ethersproject/transactions@^5.0.0-beta.135":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.5.0.tgz#7e9bf72e97bcdf69db34fe0d59e2f4203c7a2908"
   integrity sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==
@@ -813,6 +1034,21 @@
     "@ethersproject/rlp" "^5.6.1"
     "@ethersproject/signing-key" "^5.6.2"
 
+"@ethersproject/transactions@^5.5.0", "@ethersproject/transactions@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
+  integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+
 "@ethersproject/units@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/units/-/units-5.5.0.tgz#104d02db5b5dc42cc672cc4587bafb87a95ee45e"
@@ -831,7 +1067,7 @@
     "@ethersproject/constants" "^5.6.1"
     "@ethersproject/logger" "^5.6.0"
 
-"@ethersproject/wallet@5.5.0", "@ethersproject/wallet@^5.4.0":
+"@ethersproject/wallet@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wallet/-/wallet-5.5.0.tgz#322a10527a440ece593980dca6182f17d54eae75"
   integrity sha512-Mlu13hIctSYaZmUOo7r2PhNSd8eaMPVXe1wxrz4w4FCE4tDYBywDH+bAR1Xz2ADyXGwqYMwstzTrtUVIsKDO0Q==
@@ -873,7 +1109,7 @@
     "@ethersproject/transactions" "^5.6.2"
     "@ethersproject/wordlists" "^5.6.1"
 
-"@ethersproject/web@5.5.1", "@ethersproject/web@^5.5.0":
+"@ethersproject/web@5.5.1":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.5.1.tgz#cfcc4a074a6936c657878ac58917a61341681316"
   integrity sha512-olvLvc1CB12sREc1ROPSHTdFCdvMh0J5GSJYiQg2D0hdD4QmJDy8QYDb1CvoqD/bF1c++aeKv2sR5uduuG9dQg==
@@ -895,7 +1131,18 @@
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
 
-"@ethersproject/wordlists@5.5.0", "@ethersproject/wordlists@^5.5.0":
+"@ethersproject/web@^5.5.0", "@ethersproject/web@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
+  integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
+  dependencies:
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/wordlists@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.5.0.tgz#aac74963aa43e643638e5172353d931b347d584f"
   integrity sha512-bL0UTReWDiaQJJYOC9sh/XcRu/9i2jMrzf8VLRmPKx58ckSlOJiohODkECCO50dtLZHcGU6MLXQ4OOrgBwP77Q==
@@ -916,6 +1163,17 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
     "@ethersproject/strings" "^5.6.1"
+
+"@ethersproject/wordlists@^5.5.0", "@ethersproject/wordlists@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/wordlists/-/wordlists-5.7.0.tgz#8fb2c07185d68c3e09eb3bfd6e779ba2774627f5"
+  integrity sha512-S2TFNJNfHWVHNE6cNDjbVlZ6MgE17MIxMbMg2zv3wn+3XSJGosL1m9ZVv3GXCf/2ymSsQ+hRI5IzoMJTG6aoVA==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
@@ -1549,7 +1807,7 @@ adm-zip@^0.4.16:
 aes-js@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/aes-js/-/aes-js-3.0.0.tgz#e21df10ad6c2053295bcbb8dab40b09dbea87e4d"
-  integrity sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=
+  integrity sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw==
 
 aes-js@^3.1.1:
   version "3.1.2"
@@ -1596,10 +1854,15 @@ ansi-colors@3.2.3:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.3.tgz#57d35b8686e851e2cc04c403f1c00203976a1813"
   integrity sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==
 
-ansi-colors@4.1.1, ansi-colors@^4.1.1:
+ansi-colors@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.1.tgz#cbb9ae256bf750af1eab344f229aa27fe94ba348"
   integrity sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+
+ansi-colors@^4.1.1:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
+  integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
 
 ansi-escapes@^3.2.0:
   version "3.2.0"
@@ -1822,7 +2085,7 @@ async@^2.0.1, async@^2.1.2, async@^2.4.0, async@^2.5.0, async@^2.6.1:
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 at-least-node@^1.0.0:
   version "1.0.0"
@@ -3383,14 +3646,14 @@ debug@3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@4, debug@^4.0.1, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3:
+debug@4, debug@^4.0.1, debug@^4.1.1, debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
   dependencies:
     ms "2.1.2"
 
-debug@4.3.4:
+debug@4.3.4, debug@^4.3.2:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -3575,7 +3838,7 @@ defined@~1.0.0:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 delimit-stream@0.1.0:
   version "0.1.0"
@@ -5008,7 +5271,7 @@ flow-stoplight@^1.0.0:
 fmix@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/fmix/-/fmix-0.1.0.tgz#c7bbf124dec42c9d191cfb947d0a9778dd986c0c"
-  integrity sha1-x7vxJN7ELJ0ZHPuUfQqXeN2YbAw=
+  integrity sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==
   dependencies:
     imul "^1.0.0"
 
@@ -5019,10 +5282,15 @@ follow-redirects@1.5.10:
   dependencies:
     debug "=3.1.0"
 
-follow-redirects@^1.12.1, follow-redirects@^1.14.0:
+follow-redirects@^1.12.1:
   version "1.14.8"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.8.tgz#016996fb9a11a100566398b1c6839337d7bfa8fc"
   integrity sha512-1x0S9UVJHsQprFcEC/qnNzBLcIxsjAV905f/UkQxbclCsoTWlacCNOpQa/anodLl2uaEKFhfWOvM2Qg77+15zA==
+
+follow-redirects@^1.14.0:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
 
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"
@@ -5112,9 +5380,9 @@ fs-extra@^0.30.0:
     rimraf "^2.2.8"
 
 fs-extra@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
-  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.1.0.tgz#02873cfbc4084dde127eaa5f9905eef2325d1abf"
+  integrity sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==
   dependencies:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
@@ -5237,7 +5505,16 @@ get-func-name@^2.0.0:
   resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
   integrity sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=
 
-get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
+get-intrinsic@^1.0.2:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
+  integrity sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.3"
+
+get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
   integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
@@ -5396,10 +5673,15 @@ got@^7.1.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.9, graceful-fs@^4.2.4:
   version "4.2.9"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.9.tgz#041b05df45755e587a24942279b9d113146e1c96"
   integrity sha512-NtNxqUcXgpW2iMrfqSfR73Glt39K+BLwWsPs94yR63v45T0Wbej7eRmL5cWfwEgqXnmjQp3zaJTshdRW/qC2ZQ==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.10"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
+  integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
 growl@1.10.5:
   version "1.10.5"
@@ -5427,33 +5709,24 @@ hardhat-contract-sizer@^2.5.0:
     chalk "^4.0.0"
     cli-table3 "^0.6.0"
 
-hardhat-deploy@^0.9.27:
-  version "0.9.29"
-  resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.9.29.tgz#b1177d4f3077f335ad3f50c55825d9417ec75968"
-  integrity sha512-8tIGszPFmOaXtyloCbASiZPvoAgLNGGL/Ubys3YW/oj4dvoPa8G6YDyaOCdsAhsENZ+QgR280NFSG9JdN7SU9Q==
+hardhat-deploy@^0.11.15:
+  version "0.11.15"
+  resolved "https://registry.yarnpkg.com/hardhat-deploy/-/hardhat-deploy-0.11.15.tgz#5b5f6f762caa3c4d30e6e2800379ea7817a861b5"
+  integrity sha512-7e/GfVLmSXlcVePVFbC/xZ8mD97ChR6gHeUbejWMvzXpZ6I5bjSPZuaH5AebRRlb/6LjeIrN1+bKnayY0Sw9aA==
   dependencies:
-    "@ethersproject/abi" "^5.4.0"
-    "@ethersproject/abstract-signer" "^5.4.1"
-    "@ethersproject/address" "^5.4.0"
-    "@ethersproject/bignumber" "^5.4.1"
-    "@ethersproject/bytes" "^5.4.0"
-    "@ethersproject/constants" "^5.4.0"
-    "@ethersproject/contracts" "^5.4.1"
-    "@ethersproject/providers" "^5.4.4"
-    "@ethersproject/solidity" "^5.4.0"
-    "@ethersproject/transactions" "^5.4.0"
-    "@ethersproject/wallet" "^5.4.0"
     "@types/qs" "^6.9.7"
     axios "^0.21.1"
     chalk "^4.1.2"
     chokidar "^3.5.2"
     debug "^4.3.2"
     enquirer "^2.3.6"
+    ethers "^5.5.3"
     form-data "^4.0.0"
     fs-extra "^10.0.0"
     match-all "^1.2.6"
     murmur-128 "^0.2.1"
     qs "^6.9.4"
+    zksync-web3 "^0.8.1"
 
 hardhat-gas-reporter@^1.0.6:
   version "1.0.8"
@@ -5545,10 +5818,15 @@ has-symbol-support-x@^1.4.1:
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
   integrity sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==
 
-has-symbols@^1.0.0, has-symbols@^1.0.1, has-symbols@^1.0.2:
+has-symbols@^1.0.0, has-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
   integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
+
+has-symbols@^1.0.1, has-symbols@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
+  integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
 
 has-to-string-tag-x@^1.2.0:
   version "1.4.1"
@@ -5640,7 +5918,7 @@ heap@0.2.6:
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
-  integrity sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=
+  integrity sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==
   dependencies:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
@@ -5779,7 +6057,7 @@ import-fresh@^3.0.0, import-fresh@^3.2.1:
 imul@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/imul/-/imul-1.0.1.tgz#9d5867161e8b3de96c2c38d5dc7cb102f35e2ac9"
-  integrity sha1-nVhnFh6LPelsLDjV3HyxAvNeKsk=
+  integrity sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -5998,7 +6276,7 @@ is-extendable@^1.0.1:
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
-  integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+  integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
 is-finite@^1.0.0:
   version "1.1.0"
@@ -7016,7 +7294,19 @@ mime-db@1.51.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
   integrity sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==
 
-mime-types@^2.1.12, mime-types@^2.1.16, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
+
+mime-types@^2.1.16, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.34"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.34.tgz#5a712f9ec1503511a945803640fafe09d3793c24"
   integrity sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==
@@ -7058,7 +7348,7 @@ minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
 minimalistic-crypto-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
-  integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
+  integrity sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==
 
 minimatch@3.0.4:
   version "3.0.4"
@@ -7429,10 +7719,15 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.11.0, object-inspect@^1.9.0, object-inspect@~1.12.0:
+object-inspect@^1.11.0, object-inspect@~1.12.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
+
+object-inspect@^1.9.0:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.2.tgz#c0641f26394532f28ab8d796ab954e43c009a8ea"
+  integrity sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==
 
 object-is@^1.0.1:
   version "1.1.5"
@@ -8105,10 +8400,17 @@ qs@6.9.6:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
   integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
 
-qs@^6.4.0, qs@^6.7.0, qs@^6.9.4:
+qs@^6.4.0, qs@^6.7.0:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.10.3.tgz#d6cde1b2ffca87b5aa57889816c5f81535e22e8e"
   integrity sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==
+  dependencies:
+    side-channel "^1.0.4"
+
+qs@^6.9.4:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
 
@@ -10822,3 +11124,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zksync-web3@^0.8.1:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.8.1.tgz#db289d8f6caf61f4d5ddc471fa3448d93208dc14"
+  integrity sha512-1A4aHPQ3MyuGjpv5X/8pVEN+MdZqMjfVmiweQSRjOlklXYu65wT9BGEOtCmMs5d3gIvLp4ssfTeuR5OCKOD2kw==


### PR DESCRIPTION
We want to upgrade `hardhat-deploy` dependency to latest version. Previously used version is not working correctly with a `@nomiclabs/hardhat-etherscan` plugin which we plan to use in the near future.
Apart from updating `package.lock` and `yarn.lock`, we had to change how we store the Etherscan key in Hardhat config file, because the syntax for that got changed in the newer versions of `hardhat-deploy`.

TODO:

- [x] fix failing unit tests