### PR TITLE
Use floating pragma for IApplication and IStaking interfaces

### DIFF
--- a/contracts/staking/IApplication.sol
+++ b/contracts/staking/IApplication.sol
@@ -13,7 +13,7 @@
 //               ▐████▌    ▐████▌
 //               ▐████▌    ▐████▌
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.9;
 
 /// @title  Application interface for Threshold Network applications
 /// @notice Generic interface for an application. Application is an external

--- a/contracts/staking/IStaking.sol
+++ b/contracts/staking/IStaking.sol
@@ -13,7 +13,7 @@
 //               ▐████▌    ▐████▌
 //               ▐████▌    ▐████▌
 
-pragma solidity 0.8.9;
+pragma solidity ^0.8.9;
 
 /// @title Interface of Threshold Network staking contract
 /// @notice The staking contract enables T owners to have their wallets offline


### PR DESCRIPTION
Pragma statements are fine to float when a contract is intended for consumption by contracts from another project. This is the case for IApplication and IStaking that are imported from tBTC v2 contracts. If we do not use the floating pragma, all tBTC v2 contracts would need to stay on 0.8.9 and now use the more recent Solidity versions.