### PR TITLE
Upgrade version of Node used in CI to `v18`

### DIFF
--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "18.x"
           cache: "yarn"
 
       - name: Install dependencies
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "18.x"
           cache: "yarn"
 
       - name: Install dependencies
@@ -104,7 +104,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "18.x"
           cache: "yarn"
 
       - name: Install dependencies
@@ -124,7 +124,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "18.x"
           cache: "yarn"
           registry-url: "https://registry.npmjs.org"
 
@@ -193,7 +193,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "18.x"
           cache: "yarn"
 
       - name: Install needed dependencies
@@ -229,7 +229,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "18.x"
           cache: "yarn"
           registry-url: "https://registry.npmjs.org"
 
@@ -284,7 +284,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "18"
           cache: "yarn"
 
       - uses: actions/setup-python@v4

--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14"
+          node-version: "18"
           cache: "yarn"
 
       - name: Install dependencies

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "14.x"
+          node-version: "18.x"
           registry-url: "https://registry.npmjs.org"
           cache: "yarn"
 


### PR DESCRIPTION
Previously we'we been using `v14` of Node.js. But there are several newer versions available. The highest version supported by the `actions/setup-node@v3` action is `v18`. We want to upgrade from `v14` across all our modules, because this version started to cause some problems (failing `yarn upgrade` commands) with some of the modules.