### PR TITLE
Cleaning up Slither and Linting - unblocking CI checks

### DIFF
--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -215,6 +215,7 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     }
 
     modifier onlyOwnerOf(address stakingProvider) {
+        // slither-disable-next-line incorrect-equality
         require(
             stakingProviders[stakingProvider].owner == msg.sender,
             "Caller is not owner"

--- a/test/staking/TokenStaking.test.js
+++ b/test/staking/TokenStaking.test.js
@@ -1379,9 +1379,7 @@ describe("TokenStaking", () => {
           tx = await tokenStaking.stakeKeep(stakingProvider.address)
 
           await nucypherStakingMock.setStaker(staker.address, nuStake)
-          await tokenStaking
-            .connect(staker)
-            .topUpNu(stakingProvider.address)
+          await tokenStaking.connect(staker).topUpNu(stakingProvider.address)
 
           await tToken.connect(staker).approve(tokenStaking.address, tStake)
           await tokenStaking
@@ -3537,9 +3535,7 @@ describe("TokenStaking", () => {
         await tokenStaking
           .connect(staker)
           .unstakeNu(stakingProvider.address, nuInTAmount)
-        tx = await tokenStaking
-          .connect(staker)
-          .topUpNu(stakingProvider.address)
+        tx = await tokenStaking.connect(staker).topUpNu(stakingProvider.address)
       })
 
       it("should update only Nu staked amount", async () => {
@@ -3657,9 +3653,7 @@ describe("TokenStaking", () => {
         blockTimestamp = await lastBlockTime()
 
         await nucypherStakingMock.setStaker(staker.address, nuAmount)
-        tx = await tokenStaking
-          .connect(staker)
-          .topUpNu(stakingProvider.address)
+        tx = await tokenStaking.connect(staker).topUpNu(stakingProvider.address)
       })
 
       it("should update only Nu staked amount", async () => {


### PR DESCRIPTION
This PR cleans up existing code by linting a test file and disables "incorrect-equality" slither check for one of the `require` statements. 

These changes are needed to pass CI checks in other PR and currently is a blocker. For some reason, CI didn't catch linting and slither issues when the actual code was merged to the main branch here https://github.com/threshold-network/solidity-contracts/commit/f468a7d8a3aa84bf65f0819b521302efe46d016b