### PR TITLE
Set Node.js version to 18.15.0

### DIFF
--- a/.github/workflows/contracts.yaml
+++ b/.github/workflows/contracts.yaml
@@ -59,7 +59,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          # Using fixed version, because 18.16 was sometimes causing issues with
+          # artifacts generation during `hardhat compile` - see
+          # https://github.com/NomicFoundation/hardhat/issues/3877
+          node-version: "18.15.0"
           cache: "yarn"
 
       - name: Install dependencies
@@ -83,7 +86,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          # Using fixed version, because 18.16 was sometimes causing issues with
+          # artifacts generation during `hardhat compile` - see
+          # https://github.com/NomicFoundation/hardhat/issues/3877
+          node-version: "18.15.0"
           cache: "yarn"
 
       - name: Install dependencies
@@ -104,7 +110,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          # Using fixed version, because 18.16 was sometimes causing issues with
+          # artifacts generation during `hardhat compile` - see
+          # https://github.com/NomicFoundation/hardhat/issues/3877
+          node-version: "18.15.0"
           cache: "yarn"
 
       - name: Install dependencies
@@ -124,7 +133,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          # Using fixed version, because 18.16 was sometimes causing issues with
+          # artifacts generation during `hardhat compile` - see
+          # https://github.com/NomicFoundation/hardhat/issues/3877
+          node-version: "18.15.0"
           cache: "yarn"
           registry-url: "https://registry.npmjs.org"
 
@@ -193,7 +205,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          # Using fixed version, because 18.16 was sometimes causing issues with
+          # artifacts generation during `hardhat compile` - see
+          # https://github.com/NomicFoundation/hardhat/issues/3877
+          node-version: "18.15.0"
           cache: "yarn"
 
       - name: Install needed dependencies
@@ -229,7 +244,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18.x"
+          # Using fixed version, because 18.16 was sometimes causing issues with
+          # artifacts generation during `hardhat compile` - see
+          # https://github.com/NomicFoundation/hardhat/issues/3877
+          node-version: "18.15.0"
           cache: "yarn"
           registry-url: "https://registry.npmjs.org"
 
@@ -284,7 +302,10 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: "18"
+          # Using fixed version, because 18.16 was sometimes causing issues with
+          # artifacts generation during `hardhat compile` - see
+          # https://github.com/NomicFoundation/hardhat/issues/3877
+          node-version: "18.15.0"
           cache: "yarn"
 
       - uses: actions/setup-python@v4


### PR DESCRIPTION
We want to fix problem with the `yarn build` (`hardhat compile`) command sometimes not generating expected artifacts. The problem is caused by the process silently quitting, which is related to the used version of Node (as descibed in NomicFoundation/hardhat#3877). We've confirmed the problem is reproducible on `v18.16.0`, now we're downgrading to `v18.15.0` to fix the issue.

Ref:
https://github.com/threshold-network/solidity-contracts/pull/145