### PR TITLE
Adding interface for applications that use operator role and delay in…

### DIFF
--- a/contracts/staking/IApplicationWithDecreaseDelay.sol
+++ b/contracts/staking/IApplicationWithDecreaseDelay.sol
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity ^0.8.9;
+
+import "./IApplication.sol";
+
+/// @title  Interface for Threshold Network applications with delay after decrease request
+interface IApplicationWithDecreaseDelay is IApplication {
+    /// @notice Returns authorization-related parameters of the application.
+    /// @dev The minimum authorization is also returned by `minimumAuthorization()`
+    ///      function, as a requirement of `IApplication` interface.
+    /// @return _minimumAuthorization The minimum authorization amount required
+    ///         so that operator can participate in the application.
+    /// @return authorizationDecreaseDelay Delay in seconds that needs to pass
+    ///         between the time authorization decrease is requested and the
+    ///         time that request gets approved. Protects against free-riders
+    ///         earning rewards and not being active in the network.
+    /// @return authorizationDecreaseChangePeriod Authorization decrease change
+    ///        period in seconds. It is the time, before authorization decrease
+    ///        delay end, during which the pending authorization decrease
+    ///        request can be overwritten.
+    ///        If set to 0, pending authorization decrease request can not be
+    ///        overwritten until the entire `authorizationDecreaseDelay` ends.
+    ///        If set to value equal `authorizationDecreaseDelay`, request can
+    ///        always be overwritten.
+    function authorizationParameters()
+        external
+        view
+        returns (
+            uint96 _minimumAuthorization,
+            uint64 authorizationDecreaseDelay,
+            uint64 authorizationDecreaseChangePeriod
+        );
+
+    /// @notice Returns the amount of stake that is pending authorization
+    ///         decrease for the given staking provider. If no authorization
+    ///         decrease has been requested, returns zero.
+    function pendingAuthorizationDecrease(address _stakingProvider)
+        external
+        view
+        returns (uint96);
+
+    /// @notice Returns the remaining time in seconds that needs to pass before
+    ///         the requested authorization decrease can be approved.
+    function remainingAuthorizationDecreaseDelay(address stakingProvider)
+        external
+        view
+        returns (uint64);
+
+    /// @notice Approves the previously registered authorization decrease
+    ///         request. Reverts if authorization decrease delay has not passed
+    ///         yet or if the authorization decrease was not requested for the
+    ///         given staking provider.
+    function approveAuthorizationDecrease(address stakingProvider) external;
+}

--- a/contracts/staking/IApplicationWithDecreaseDelay.sol
+++ b/contracts/staking/IApplicationWithDecreaseDelay.sol
@@ -26,15 +26,15 @@ interface IApplicationWithDecreaseDelay is IApplication {
     ///         so that operator can participate in the application.
     /// @return authorizationDecreaseDelay Delay in seconds that needs to pass
     ///         between the time authorization decrease is requested and the
-    ///         time that request gets approved. Protects against free-riders
+    ///         time that request gets approved. Protects against participants
     ///         earning rewards and not being active in the network.
     /// @return authorizationDecreaseChangePeriod Authorization decrease change
-    ///        period in seconds. It is the time, before authorization decrease
-    ///        delay end, during which the pending authorization decrease
+    ///        period in seconds. It is the time window, before authorization decrease
+    ///        delay ends, during which the pending authorization decrease
     ///        request can be overwritten.
     ///        If set to 0, pending authorization decrease request can not be
     ///        overwritten until the entire `authorizationDecreaseDelay` ends.
-    ///        If set to value equal `authorizationDecreaseDelay`, request can
+    ///        If set to a value equal to `authorizationDecreaseDelay`, request can
     ///        always be overwritten.
     function authorizationParameters()
         external

--- a/contracts/staking/IApplicationWithOperator.sol
+++ b/contracts/staking/IApplicationWithOperator.sol
@@ -26,11 +26,11 @@ interface IApplicationWithOperator is IApplication {
         returns (address);
 
     /// @notice Used by staking provider to set operator address that will
-    ///         operate a node. The operator addressmust be unique.
+    ///         operate a node. The operator address must be unique.
     ///         Reverts if the operator is already set for the staking provider
     ///         or if the operator address is already in use.
     /// @dev    Depending on application the given staking provider can set operator
-    ///         address only one or multiple times. Besides that application can decide
+    ///         address only once or multiple times. Besides that, application can decide
     ///         if function reverts if there is a pending authorization decrease for
     ///         the staking provider.
     function registerOperator(address operator) external;

--- a/contracts/staking/IApplicationWithOperator.sol
+++ b/contracts/staking/IApplicationWithOperator.sol
@@ -25,6 +25,12 @@ interface IApplicationWithOperator is IApplication {
         view
         returns (address);
 
+    /// @notice Returns staking provider of the given operator.
+    function operatorToStakingProvider(address operator)
+        external
+        view
+        returns (address);
+
     /// @notice Used by staking provider to set operator address that will
     ///         operate a node. The operator address must be unique.
     ///         Reverts if the operator is already set for the staking provider

--- a/contracts/staking/IApplicationWithOperator.sol
+++ b/contracts/staking/IApplicationWithOperator.sol
@@ -40,9 +40,4 @@ interface IApplicationWithOperator is IApplication {
     ///         if function reverts if there is a pending authorization decrease for
     ///         the staking provider.
     function registerOperator(address operator) external;
-
-    // TODO consider that?
-    // /// @notice Used by additional role (owner for example) to set operator address that will
-    // ///         operate a node for the specified staking provider.
-    // function registerOperator(address stakingProvider, address operator) external;
 }

--- a/contracts/staking/IApplicationWithOperator.sol
+++ b/contracts/staking/IApplicationWithOperator.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+// ██████████████     ▐████▌     ██████████████
+// ██████████████     ▐████▌     ██████████████
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+//               ▐████▌    ▐████▌
+
+pragma solidity ^0.8.9;
+
+import "./IApplication.sol";
+
+/// @title  Interface for Threshold Network applications with operator role
+interface IApplicationWithOperator is IApplication {
+    /// @notice Returns operator registered for the given staking provider.
+    function stakingProviderToOperator(address stakingProvider)
+        external
+        view
+        returns (address);
+
+    /// @notice Used by staking provider to set operator address that will
+    ///         operate a node. The operator addressmust be unique.
+    ///         Reverts if the operator is already set for the staking provider
+    ///         or if the operator address is already in use.
+    /// @dev    Depending on application the given staking provider can set operator
+    ///         address only one or multiple times. Besides that application can decide
+    ///         if function reverts if there is a pending authorization decrease for
+    ///         the staking provider.
+    function registerOperator(address operator) external;
+
+    // TODO consider that?
+    // /// @notice Used by additional role (owner for example) to set operator address that will
+    // ///         operate a node for the specified staking provider.
+    // function registerOperator(address stakingProvider, address operator) external;
+}


### PR DESCRIPTION
… authorization decrease.

Fixes #156

Main suggestion here is to use both interfaces for all apps: TBCv2, RandomBeacon, TACo.
Names for method inherit those from `RandomBeacon` and `TBTCv2`, except one additional method to register operator using additional role (please leave comment: remove or keep it).
That unification will help with tracking changes between TBTC and TACo contracts, simplify dashboard interaction with contracts and also help with contract pool developing in the future. 