### PR TITLE
Update version of `upload-artifact` and `dowload-artifact` to `v4`

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -156,7 +156,7 @@ jobs:
           version: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Upload files needed for etherscan verification
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Artifacts for etherscan verifcation
           path: |
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Download files needed for etherscan verification
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Artifacts for etherscan verifcation
 


### PR DESCRIPTION
The `v3` of the `actions/upload-artifact` and `actions/download-artifact` actions got
[deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) causing possible failure of workflow execution. We're upgrading to `v4` of the actions. Although there are some breaking changes in `v4` compared to `v3`, they do not affect our setup.