### PR TITLE
chore: track OpenZeppelin Sepolia upgrade manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ yarn-error.log
 
 # OpenZeppelin
 .openzeppelin/unknown-*.json
+!.openzeppelin/unknown-11155111.json
 
 # Generated operator setup artifacts
 operator-*-keystore/

--- a/.openzeppelin/unknown-11155111.json
+++ b/.openzeppelin/unknown-11155111.json
@@ -1,0 +1,11914 @@
+{
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x079521d08C0F36a0255E6337DF9623aF3A13E561",
+    "txHash": "0xb3c04c59bf63c529812a6f90837062b73589f3e070670414cfd80e6442c135d2",
+    "deployTransaction": {
+      "hash": "0xb3c04c59bf63c529812a6f90837062b73589f3e070670414cfd80e6442c135d2",
+      "type": 2,
+      "accessList": [],
+      "blockHash": null,
+      "blockNumber": null,
+      "transactionIndex": null,
+      "confirmations": 0,
+      "from": "0xf6287aa4823976fA3366e33a3F005a074062E41c",
+      "gasPrice": {
+        "type": "BigNumber",
+        "hex": "0x124f8d"
+      },
+      "maxPriorityFeePerGas": {
+        "type": "BigNumber",
+        "hex": "0x124f80"
+      },
+      "maxFeePerGas": {
+        "type": "BigNumber",
+        "hex": "0x124f8d"
+      },
+      "gasLimit": {
+        "type": "BigNumber",
+        "hex": "0x0776c2"
+      },
+      "to": null,
+      "value": {
+        "type": "BigNumber",
+        "hex": "0x00"
+      },
+      "nonce": 18489,
+      "data": "0x608060405234801561001057600080fd5b50600080546001600160a01b031916339081178255604051909182917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908290a350610759806100616000396000f3fe60806040526004361061007b5760003560e01c80639623609d1161004e5780639623609d1461011157806399a88ec414610124578063f2fde38b14610144578063f3b7dead146101645761007b565b8063204e1c7a14610080578063715018a6146100bc5780637eff275e146100d35780638da5cb5b146100f3575b600080fd5b34801561008c57600080fd5b506100a061009b366004610515565b610184565b6040516001600160a01b03909116815260200160405180910390f35b3480156100c857600080fd5b506100d1610215565b005b3480156100df57600080fd5b506100d16100ee366004610554565b610292565b3480156100ff57600080fd5b506000546001600160a01b03166100a0565b6100d161011f36600461058c565b61031c565b34801561013057600080fd5b506100d161013f366004610554565b6103ad565b34801561015057600080fd5b506100d161015f366004610515565b610405565b34801561017057600080fd5b506100a061017f366004610515565b6104ef565b6000806000836001600160a01b03166040516101aa90635c60da1b60e01b815260040190565b600060405180830381855afa9150503d80600081146101e5576040519150601f19603f3d011682016040523d82523d6000602084013e6101ea565b606091505b5091509150816101f957600080fd5b8080602001905181019061020d9190610538565b949350505050565b6000546001600160a01b031633146102485760405162461bcd60e51b815260040161023f906106c0565b60405180910390fd5b600080546040516001600160a01b03909116907f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0908390a3600080546001600160a01b0319169055565b6000546001600160a01b031633146102bc5760405162461bcd60e51b815260040161023f906106c0565b6040516308f2839760e41b81526001600160a01b038281166004830152831690638f283970906024015b600060405180830381600087803b15801561030057600080fd5b505af1158015610314573d6000803e3d6000fd5b505050505050565b6000546001600160a01b031633146103465760405162461bcd60e51b815260040161023f906106c0565b60405163278f794360e11b81526001600160a01b03841690634f1ef286903490610376908690869060040161065d565b6000604051808303818588803b15801561038f57600080fd5b505af11580156103a3573d6000803e3d6000fd5b5050505050505050565b6000546001600160a01b031633146103d75760405162461bcd60e51b815260040161023f906106c0565b604051631b2ce7f360e11b81526001600160a01b038281166004830152831690633659cfe6906024016102e6565b6000546001600160a01b0316331461042f5760405162461bcd60e51b815260040161023f906106c0565b6001600160a01b0381166104945760405162461bcd60e51b815260206004820152602660248201527f4f776e61626c653a206e6577206f776e657220697320746865207a65726f206160448201526564647265737360d01b606482015260840161023f565b600080546040516001600160a01b03808516939216917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e091a3600080546001600160a01b0319166001600160a01b0392909216919091179055565b6000806000836001600160a01b03166040516101aa906303e1469160e61b815260040190565b600060208284031215610526578081fd5b81356105318161070b565b9392505050565b600060208284031215610549578081fd5b81516105318161070b565b60008060408385031215610566578081fd5b82356105718161070b565b915060208301356105818161070b565b809150509250929050565b6000806000606084860312156105a0578081fd5b83356105ab8161070b565b925060208401356105bb8161070b565b9150604084013567ffffffffffffffff808211156105d7578283fd5b818601915086601f8301126105ea578283fd5b8135818111156105fc576105fc6106f5565b604051601f8201601f19908116603f01168101908382118183101715610624576106246106f5565b8160405282815289602084870101111561063c578586fd5b82602086016020830137856020848301015280955050505050509250925092565b600060018060a01b038416825260206040818401528351806040850152825b818110156106985785810183015185820160600152820161067c565b818111156106a95783606083870101525b50601f01601f191692909201606001949350505050565b6020808252818101527f4f776e61626c653a2063616c6c6572206973206e6f7420746865206f776e6572604082015260600190565b634e487b7160e01b600052604160045260246000fd5b6001600160a01b038116811461072057600080fd5b5056fea2646970667358221220d849f96f3086b9f82cdcf665adb8c697ace05638da1c7c16ab2d26293717af6764736f6c63430008020033",
+      "r": "0x7c005c73373c204bf57e81183e8f2a6c76fcbfd46ec5b3d431f5b3bfab56f981",
+      "s": "0x703a7a9abe7cf996ce6f623841712f7ef894357aeb3945344764218e50794467",
+      "v": 1,
+      "creates": "0x079521d08C0F36a0255E6337DF9623aF3A13E561",
+      "chainId": 11155111
+    }
+  },
+  "proxies": [
+    {
+      "address": "0xea3448eD64e85C7B844550fC9E7225Bb17874bF2",
+      "txHash": "0xd5213a2f8e3f2d0042802965bfd34d4ece8e8842349f04aebd5b2a2ce1a2f35f",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x70d82956b4B946Cf59A6bd5D5d06FB605E2f1ACb",
+      "txHash": "0x187cffec53b95f48c3b557b6cd731e3908247741e2e56127ce4235255cb63036",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x69236F29941386e81Ca135411b02580A0310aea5",
+      "txHash": "0x2b7e6b6cb342f8184bb2f1d8865a64657716a646a3e4014f5129a0b1a60d6e0c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x3Eb29AE67d0422d52209d894e10F556540204a83",
+      "txHash": "0x6565aa423de3c15ead150bf4be510ecf6ccad909806f352598cdf73acc86ab5c",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xa6499df1ECdAe17697889A6CD61a505F716ae47C",
+      "txHash": "0x574d269d3a9b8b324e941a73dcaf04f5700a848b1ac79de29b10fca262fdedef",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xDc8f042A4d3491000f4D71Ef4C7AFd89de82EA2F",
+      "txHash": "0xd486123932cfcc46f2cfe152fe5c24e5899c1c45aa21e2923848e2b2beeeb2b6",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x8376B707Fd3A2008D624Fa3478E406684d203173",
+      "txHash": "0xd86b174a8fb58b623c8dca64ff923a7163ced0fe89df5b1af519662149e0fc4d",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x39cd83F90B113422A87EB0846b90D6dcE667D763",
+      "txHash": "0x6124482d910c54bfc33e7eaf8fd90b9d0154e2e935987e257b471816996f89ce",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6d1CA1Fe2dBc0f1d84D4bCCAA9eC6db5B7aa25ad",
+      "txHash": "0x53b460e65d89fbdd9bc2d039227cb3af6bfe7aea8145819f3a20c28fa8cc66b4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x676b9209F723Cd137df1774704BD5239514E9615",
+      "txHash": "0x34ab503708a01177902d00dc60739e2fc6ed39b760bc4b37bd0d97ad2999b75e",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x0AD6CC860895B0B25083fd821D44e7BE3bbFa4e6",
+      "txHash": "0x4ea741394beb6b3f2c1a16a77247ffdebca69aaa8258a3e0d85e10b05754cd8b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x4E0d94A2301ED5497272674b1d0a057D747Cad62",
+      "txHash": "0x510936d64380d75c923be1abea9e0d24ebc7f02e2e0e87fb046fb002797eecb3",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x3922820B96c73B849c6809CefdA899120788e865",
+      "txHash": "0x77b02f5e28d58f6634522ef3e1bbf0ef716e83923b9fc3c1edbdd2f1b7e4f8ef",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xEced84a117eB690dF091a7cB2E226103a5CE8f08",
+      "txHash": "0xe61ff729c05c9d8e4928c11218d90609b7d9e2002f19cad123ea18d13288ca45",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6c4ad45e9Af277244BEDf6a9bbd1d016B07Fb11c",
+      "txHash": "0xa7e14a667d53eff6dffae1f9db715cccbc6bf61e42e9cfc1a184b876f3ffc3c4",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x36b0f409Dac182F29eaca57C1647106FC8Edf523",
+      "txHash": "0x0e9906375c203e07ca672a8fa285904cdd87b014ec014162bd1e4f9ce9d25a3e",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xAc528bED816778395BeFf4963FDCB6DF1a29937f",
+      "txHash": "0x5158b8d9a719028267dc474a1d77a23012e1ca7965b43677f4c09ee9eeaa11d1",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x85846Ea6d573fc60107E86001BDb3B901c9392B2",
+      "txHash": "0x4f99526d73c38e36a4993843fdfe723c40ae815f18e06907c79ac7fd7867e0ef",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xd24fd8fE0adC06e2218516641324C0accEf5bFa6",
+      "txHash": "0x5bc981c4b7db65a3dfc0f4f7160adc9b52802528986ff24b03d82d0beaec2333",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x7982FDB8A5040CB0720b7719cBb5b6922F898FF5",
+      "txHash": "0x3dfd75059db39ac8896d5ef13f2c8a80938032b31c4162d3757f58c3d83daa7a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x475cDcB38785B1534B4500B46b8e41b74E221b0d",
+      "txHash": "0x9da0e7d4d3d8b35c53633b087706ec4fc67fdbc766eb6e33818b5612c9c75483",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x91403e90A85E3FFB8502B0AC1E138B854E8B3739",
+      "txHash": "0x5a5379c268f1b13e3a9fdfbcb533f7dadb805748661883734436f6cfb207cb26",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xE98157759F85C205522B4d5BD21c2Bb57F484437",
+      "txHash": "0x48a30fee541474559e49b9590d15efeccbe28065df106df52f117b40f98ad168",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xEAF9d8aa81271f0929FB8973Bd99AD435846f820",
+      "txHash": "0x570bd9092bbbdb8f20b8b9701945849a850ba4d084b014b4d56a2d8f79afe573",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x6af8C7971a2D46006205E480f12F3C2C9f00610E",
+      "txHash": "0x8431bf2d31bf8659cd42d3570536012cd5733bba1fc5b0419e3bfebd254af3c8",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x39010f8eF404BF37d53477F03bd6E3f325D69dA6",
+      "txHash": "0x0392538c3a5c9873dd268e011d928a318d07bcb2964646e6d8c25ac6e20c4b9b",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xC251B10966Bfb895342AaA94f840581C5251C97e",
+      "txHash": "0xafe922a8405cf069bb4c02ff10c8318071089da97e5287443f98b2c40ca14f8a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0xf7674b5ddb55Eeb91B3EE5296226Ac4D664E4657",
+      "txHash": "0xf49ff126b9cd54c9e1b42d9ab14805aaaca174cd4af4212e539c01fea616107d",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x9Ac2ba0c3e7d630e4A9Ccc4de623B93B766e4128",
+      "txHash": "0xb5b536a21087e0c685b1b0dcbff1729816362300200236e0d76a06427509e2f2",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x34A0C219dbe6B0856d47E30CA18BB24dEF2128A7",
+      "txHash": "0xca0657cf4c2da4d851ce5cbb39994935f98bfce6477b9a54f48d778ea6047d2a",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x77C08E016F6D427Db2E237529eb6b7F603E2F614",
+      "txHash": "0x14e3d49a38ef8a762d653857be71ce43ec996e73d15e1e3b135b6ca9f051a925",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x59E0cD8447D606327C8A229e80332fB07b7EE00d",
+      "txHash": "0xe80662f3b453f68afc019b56f0727106e4603240db7aefd99b2ed812a3c5df69",
+      "kind": "transparent"
+    },
+    {
+      "address": "0x3245B1a2dc82D02F7e159CA5ef14B6e35585779a",
+      "txHash": "0x5398bc04914af7e1ab3e01f3dd5d7ffb45c86bdc475112a6719711c8e4a59c8a",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "debc9f92897f3605d7e48c6b812be2d5e8ba25169cf6990d2fade70e1d3d77d3": {
+      "address": "0x2Afc184b8AAe5f29F4Fe4D96a6234AA2d5201852",
+      "txHash": "0xabd8df2292e437bca8408ef3b02c37dc59a223269b33320174a06c1e47db23da",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12030_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12041_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12046_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12030_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12030_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12035_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12035_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12035_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12041_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12041_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12003"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12003": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12046_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12046_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "bdd1d404b80170f81e319fd08e1d20d1d6122a48b964d54a555c133fd0845431": {
+      "address": "0xEFeBA08F7b03e8763dbF709E97c36d7061255D50",
+      "txHash": "0xb773e9c4387b02800613a677b6a533dec4d32e613a1c6598433eb0c651dc08cb",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "01b86cfa84858e0eff119458958b95afcfe13beb46aad4f44000d12884c6fcb1": {
+      "address": "0x0B071D083cf264A995b4f2E6145Cb2cc14fbE2d3",
+      "txHash": "0x1925c115886f1e3dcfed106478f711b9fd5df4fbcff82b4dc7082c4df3356e2f",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "115f5a4eae1e5b071574f178ed1348aad932c62986c8013533d1f65a6b1dbb08": {
+      "address": "0x6364a990fa159953749Afc4b640EF92E1cef7aB5",
+      "txHash": "0xe0f97b2c933f541418a9686f729c4e6bab0055488a965386b06baed4daf968e3",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "fe732d44d65f50908f520de6417d7bd901a5cfbf95b9433db1cb42913834cfbc": {
+      "address": "0x228AFF1Bd99f4da1a6B08e854472F001532904C3",
+      "txHash": "0x59f197e9955f25a9902de99b1305af304dd492538e2f9249e04d26bebc552d54",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "8c10ff11a219fdbdaf25b222bb2070228b15e6634cae1ff55af8e4d83d870971": {
+      "address": "0x9323aF11393867C58c422c760C308c2e23198bb4",
+      "txHash": "0xeb7f60d108dd27f3f8699acc730a1d565d0da6632e631ca116e9aae59ae545ec",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "48168e3491a7feb8121d4339010e9fe8d1876b83cf1eb3aa2084e628ade488fe": {
+      "address": "0x2EFF5Ef4Fd394d7DEd5Cbae55728f5d6f20a444A",
+      "txHash": "0xa886b9c9e674dcaae630f9af56bc393674f79e9d0f77a0b7f50f267fdc588639",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "8c9d6859ed885c12c93a9daefbeb4bb87adab50b94e75924b40aff9101f8c79b": {
+      "address": "0x723887eA7886DEeA3c9784C6897E34495df2640c",
+      "txHash": "0x479f3f6b9555badd88124a4a56370ee6f51e9d0c606699341235ffebf40efbc7",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "0d1e7e08febc20aa3b63b948824682222daff2f92c08a8756d39edde1a93e77e": {
+      "address": "0xfb6DA6C254581d47cF63655a6324978aA5804f8C",
+      "txHash": "0xab49724cdc98fa8bcda62db636517930dd0c6fd6098c420fd1248c200864f057",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "051ff3da3763450c0361a15e5b73cd73f8df18dff8eff899203fe41b82cdffcc": {
+      "address": "0x942f3BfD9d16C9D9fCfB2073BeeF821B8d5fAe9f",
+      "txHash": "0x7f9f01567af5317287623eea99663d0fec168b75c35d6bb565c2e0a3034e22af",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "4fbe0b7d1b55295554f91f96e39db4138b8518f2a15923c9d8245e32869c92a0": {
+      "address": "0xbFDC22d851aa7B5A357494c47b8842E3898706D8",
+      "txHash": "0xa0caae8e623339cffc91a0d3e40916d1b4bbdbe92eacdcb55e35be39cb1414f8",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "03562ae7101a5d508ccd436298a6a878fa5ce5fbc0e013e53b12793c98de4e1b": {
+      "address": "0x238Bc2c1cC63eB3735f89B2b3877EBE07B1cE7eb",
+      "txHash": "0x0a8c3d5f52de828aa59cfa50d85dfbf0874e39e350425bdda33d87422403caf6",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "30117eb9a414b9c7a4b8accd89b4788cd94864cd23da2bb948779261715b5469": {
+      "address": "0x34975627a24037006DE493Ba78a8097933b377bC",
+      "txHash": "0x47d5e51264b64f559055ce9c23d4eea627888f4dbf1c2578a82f0771e0164fe5",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "63f48dff5c610a6ff89863bd494f8bc705886ba3751066a1cb8040d45185ddb9": {
+      "address": "0x04F8876f121540840971B35814e56475Cf602Ca9",
+      "txHash": "0x6ecaae574bc1c2fa444363e306e706043aa498ebff7de12acf23869667ba9d58",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "b3835182588652126d5721bc7f03ff5a043b288058d24c26fdc559c302163986": {
+      "address": "0x7f65EA06E8c2CC2d0F99228Fc18eA9200251C246",
+      "txHash": "0xcb5792123cdfd2055b49b8c233365ffd46af3c642ede7c53b602eec0c6139df5",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "84ba2b8d3b4be3270f3d66fa4050e95e60b0e9c42f8d7b8dcd32a8ac5c816218": {
+      "address": "0x31CDf86A87e52709a9341bd34E8F0823949896c1",
+      "txHash": "0xa9b9ee5427e26d1ebeaf23f4c016c43bc534a4e31a2ab31d2ad2e3c8a65ca872",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "dbc2a9ddaabd971136edf03b94095dc4c040230e2b6cc22750efb589516db025": {
+      "address": "0x40A1513eEdF3AA63d89b5E15B6CdcB9A4f943c11",
+      "txHash": "0x4ffa768c4c54753264034f02e022716c85e6737aca5d683434689f32ab778f40",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "01ff8da020e822f7ecac710ac8a500bf76dbbb7ab0994dff6ed533fd11cd1398": {
+      "address": "0xF8aeb9Dbcfe68F69905CFAaB82113452709D7A73",
+      "txHash": "0x0391b18ad1f7f62c8c4ed7cbf3c10274f758707f2c4b1224b43d0db101347ca1",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "c4414aab18d89c9441837d99ef221741447d5349da9fa3f5f887ba3ada5fc9f7": {
+      "address": "0x506D752C6619EE60864581f9623EAED99027453E",
+      "txHash": "0xed76f4c7fdd382c3b2391d4c1da6fe1e365ea9edcba68d92b7ec28c0cbb4fbbd",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "b2eb444bf110ebaaa412829ae38d71ea14102c4de9cb8037b85305e0d23dc7c4": {
+      "address": "0xDA4b61e64DaD6b0117536bA9958d0220716D25B0",
+      "txHash": "0x3d3cea8f6150197e654f27c095e9448223e60f008e17ff686cd71850ef8ac1dc",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "68c57a8de944a0e5d6411794b8254af9c797efaee7a302cd235713ac5f901c89": {
+      "address": "0x9bB9f5CFFa70bdEB7f7a5C2794d6F356d78f2CEE",
+      "txHash": "0x51e5b7ad5bd96d20df55eb84104ad26d603ee6211d07bf7ae0c8125c6c9ee26f",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "372ce670151ad366a7ffd12263731594c2951b2a3e5beac9065f976a20d37686": {
+      "address": "0xe812B7Edd3e8F82A00bEa00eDEb8C2242BAEf415",
+      "txHash": "0xcad3d782d99b40243d204b955ab5017b8ece29fb6ee1f5241ed1d90c13e03b3c",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "53d825e6a67f951de3a69da936c356422d55351938927a8851f8e1adeb93cf99": {
+      "address": "0x507d05b012bC4AF83F380C32A784587FaF1977e6",
+      "txHash": "0x7c5685afc0e5cc05e79ffd14b2756e874be1673d3a58e2b9575b2271e00b04bc",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "66f29faa2ae98fffef9d193161def42a626f93c2dd7db97645683f74b1471cf9": {
+      "address": "0x3fC6216D0dB2e370aBFD06B15a2AA592615CC7Be",
+      "txHash": "0x8383d65e899a7b5f8007c99cdbedc73e1d7abb6725f1de4a31d5d5e0e8fc51ed",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "56e168a9c08319040c60ace7a6a9fd2d866913ae5d10e0b4e630325db8566460": {
+      "address": "0xBC761627c628024fD59698847B27A414261e1f07",
+      "txHash": "0x4534b1c390e8330259dbe7222b0a1b3839d5ea3fa2b7cfd6170f4c3ee1488f9e",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "13a317c5545a9d9b03073aecb30627d85f8253264fcd2867e0656ae89a8a04c7": {
+      "address": "0x0127DAfE32AB02E7e9Ee3F4Cab6c2b46cFf58F7f",
+      "txHash": "0x45b28bf8158b5b6c38f620b1028b4b05f1b79d66fff1df51449f09609ab06a13",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "93bb5c0a6a36500c4542167819a00388f85c248824b62dffc1a33ebdaef9fbc0": {
+      "address": "0x6c5F5Bf8205B7aA2599E512c3e04c0bae9969518",
+      "txHash": "0x5b504de05c8119633f04b442c986f0029a7516f0f76a06125d5480968a0718ea",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "3272a49f03ac650525f7600b72930711f3bdef0e7acd59cff0c000aaf3e918a3": {
+      "address": "0xCCACb62a07c1c53ac6077cFe920722E10F78863e",
+      "txHash": "0x9cf67db4c2d240a732320526dbafed4d9fccecad1b3f7900bb7aab3f8cabcca1",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "872ac088fdb50f000cc8f20fa0ae38a4558362c95b09148f709127fc368febc5": {
+      "address": "0x0e40ed5462e0FA14EeD9D3696f68C363cce0b901",
+      "txHash": "0xd2c2dc539819783b76a7b5a5aec2f3f928dc39361aeba65fb3180b9d1830b9ab",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "0379df18f9d5ca32a1bb2bb0edb006aa2632917ee13de54ed70114b988999739": {
+      "address": "0x4d5238Ea7D7fE16ba831eA2A8beD9f2d5F9119cc",
+      "txHash": "0xeaaa27e35d737c776da20074d3bafc41fe99c70ba7c2f9239aeafd1009eb00b8",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "4d66c231d2054cb51995bd34d398e197d59d4a578a90da701c38b6f42d45d3c8": {
+      "address": "0x923755557f4c69464fdc8f7D704D6317f4a82D96",
+      "txHash": "0xf202ab94505330b35504126a3ee4c6e30939aaa548db5e5a5333a52c3de96852",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "ce0862ba669cca057d488d35cb7ee0aad7bbce845348312270d97ff06b7163d3": {
+      "address": "0x85F368a57e0c020333033753105dd8E41480F0a1",
+      "txHash": "0x053ceb29af0ace51b78d1ccc58dbdf50d89ddfc95db48a09b8c300d8626d3093",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "9a893f93ac72cdf7021843f20bee367168badc0f82ee0bb7336c0fbdd7c19030": {
+      "address": "0x7AA249ac66E4fCA4d339BE9d6CA6bA194fdeb249",
+      "txHash": "0xd84795a18fc8c9bdb8f4ba1032189391b26bbe0afbc52bac4b7c6c0267e9f3ec",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "30f5ceaa46438be48b623e6f4c2f60d79b2dda8c9d328bd877bec1c834d9df95": {
+      "address": "0x66C8c185025466b1A23db919633d1f4e2ba4Aa02",
+      "txHash": "0xc25721c4e7b28c1ac19e23fc0f2157808250b8d724f505b103b8b1fbae66bca5",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "05d117acd548a322b8d6206435815eb709137c0937e02b88588050ed9200771c": {
+      "address": "0x7bF326e104F5e5Ecb7b59A2506e668455edAf813",
+      "txHash": "0xfaf9b1d373ae3697c2c27a9bb749b455bb009e238ec486d1e5a462530df7d28a",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "3e5022ee3d95151c4ecb7dcdac805b372b33f350d1412b957a24e902129bbb13": {
+      "address": "0xA145b6dfA931DE2e1e22C5945FB7bfeEFBFf1aB6",
+      "txHash": "0xd3710ce737d6b9dcb8d5513dde5d3f0505dcc818f288a73d919965605916abb3",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "f0eb658558bce4af9c22e11e392a32582117cbee8c308ed07aa2627d48dbe255": {
+      "address": "0x3173e76b58c2aCD25d27353C75db9F53b5061e71",
+      "txHash": "0x631237c10e8f987fc36d01c8f6b7a23c5a218131e7cfce674a4b0be42ba10951",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "c59b18541df0aeae8b8fa3a3b6040ffeab9f102268068b972e1b82e46ba57bef": {
+      "address": "0x530907021812F0A4ba0CfEF94C79fb4CFd36eE29",
+      "txHash": "0x7eb174601596d97462689d0cbe5c181bf0eebd57767f98d345b2a63808e4efe6",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "27076bd6c8732c2cf1a8526399e3ad4ca462ce0dbb323bb309739519b0806a9a": {
+      "address": "0x45141f3EE099504Ed4853544CABCC2658a18fe8F",
+      "txHash": "0x28a61e388c7b745465906fc9a7fc0e9efffb523c709bfec3d865e7a8612840eb",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "5df3b12ad93d82358ddf98444455c3265300c770f502964c6860a890d38d255f": {
+      "address": "0x0D3523545E544521052b2De17ec87f011CFe1bbF",
+      "txHash": "0x120d420e31621a8a0920313c9f336cd7e0cb3890a933099b1c192d7b84d02d46",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "abbf342ace9e6b92a5763c53bfb281ee722bf9ed5742d7de8f2aa44d970798a8": {
+      "address": "0xb2E4FFD352d6D6097266071f33EC3010008e57B5",
+      "txHash": "0x87fad5c8218310d2a9364d836917417b4f6b0bb74826eca8a03ffca4ca686eab",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "2c4c7f58d4ea4f742367e1516d5bf2c6fe979d6ae3d6d1cc3dac4eda2df72d38": {
+      "address": "0x8ab18aab0c771E69De36Fd6f690B671a831eD636",
+      "txHash": "0x28ed44eaaaa9294469ab22de71367aa939456d30ae795c9b050c207f4afa90e2",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "ecf53e80d8e3ab1cc4830c31ec635396fb403c203b5f6238723e1dcd6cc769db": {
+      "address": "0x8Ab27aBa07b4a465cd93a4d80b268DB11B8EDD23",
+      "txHash": "0x068820b134a0f1f73c5931ece88786a81dbb21f59e833508c7aa79aaffc1d4fd",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "89a72ed18753df070899347892bd30bed08e4cc2550ecb75631b25462e751344": {
+      "address": "0x6e130EA13C20c1D0c1e70182F6138DE70795cA21",
+      "txHash": "0x8fb4d4c6967b24aecfa8bf2e028f9a9b8f8b96e78161c05357ac5dbec76d374a",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    },
+    "4bb4fed70318567272ae3394505338dd3e976dd5451a572b8324c109142231ea": {
+      "address": "0x3299a270903076d67C0b6C43886282A27a09dE25",
+      "txHash": "0x05a204b833741e4a1dadacaa12ba34c62a2525e630e579129fbafc79ad5ecf8b",
+      "layout": {
+        "storage": [
+          {
+            "contract": "Initializable",
+            "label": "_initialized",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:39"
+          },
+          {
+            "contract": "Initializable",
+            "label": "_initializing",
+            "type": "t_bool",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:44"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_delegates",
+            "type": "t_mapping(t_address,t_address)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_checkpoints",
+            "type": "t_mapping(t_address,t_array(t_uint128)dyn_storage)",
+            "src": "contracts/governance/Checkpoints.sol:49"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "_totalSupplyCheckpoints",
+            "type": "t_array(t_uint128)dyn_storage",
+            "src": "contracts/governance/Checkpoints.sol:51"
+          },
+          {
+            "contract": "Checkpoints",
+            "label": "__gap",
+            "type": "t_array(t_uint256)47_storage",
+            "src": "contracts/governance/Checkpoints.sol:61"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "governance",
+            "type": "t_address",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "minTStakeAmount",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:104"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "authorizationCeiling",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:105"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyPenalty",
+            "type": "t_uint96",
+            "src": "contracts/staking/TokenStaking.sol:108"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyStakeDiscrepancyRewardMultiplier",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:110"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "notifiersTreasury",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:111"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacyNotificationReward",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:114"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "stakingProviders",
+            "type": "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)",
+            "src": "contracts/staking/TokenStaking.sol:116"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applicationInfo",
+            "type": "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)",
+            "src": "contracts/staking/TokenStaking.sol:118"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "applications",
+            "type": "t_array(t_address)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:121"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueue",
+            "type": "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage",
+            "src": "contracts/staking/TokenStaking.sol:123"
+          },
+          {
+            "contract": "TokenStaking",
+            "label": "legacySlashingQueueIndex",
+            "type": "t_uint256",
+            "src": "contracts/staking/TokenStaking.sol:127"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address"
+          },
+          "t_uint96": {
+            "label": "uint96"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_struct(StakingProviderInfo)12046_storage)": {
+            "label": "mapping(address => struct TokenStaking.StakingProviderInfo)"
+          },
+          "t_struct(StakingProviderInfo)12046_storage": {
+            "label": "struct TokenStaking.StakingProviderInfo",
+            "members": [
+              {
+                "label": "nuInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "owner",
+                "type": "t_address"
+              },
+              {
+                "label": "keepInTStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "beneficiary",
+                "type": "t_address_payable"
+              },
+              {
+                "label": "tStake",
+                "type": "t_uint96"
+              },
+              {
+                "label": "authorizer",
+                "type": "t_address"
+              },
+              {
+                "label": "authorizations",
+                "type": "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)"
+              },
+              {
+                "label": "authorizedApplications",
+                "type": "t_array(t_address)dyn_storage"
+              },
+              {
+                "label": "startStakingTimestamp",
+                "type": "t_uint256"
+              },
+              {
+                "label": "autoIncrease",
+                "type": "t_bool"
+              },
+              {
+                "label": "optOutAmount",
+                "type": "t_uint256"
+              }
+            ]
+          },
+          "t_address_payable": {
+            "label": "address payable"
+          },
+          "t_mapping(t_address,t_struct(AppAuthorization)12051_storage)": {
+            "label": "mapping(address => struct TokenStaking.AppAuthorization)"
+          },
+          "t_struct(AppAuthorization)12051_storage": {
+            "label": "struct TokenStaking.AppAuthorization",
+            "members": [
+              {
+                "label": "authorized",
+                "type": "t_uint96"
+              },
+              {
+                "label": "deauthorizing",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]"
+          },
+          "t_bool": {
+            "label": "bool"
+          },
+          "t_mapping(t_address,t_struct(ApplicationInfo)12057_storage)": {
+            "label": "mapping(address => struct TokenStaking.ApplicationInfo)"
+          },
+          "t_struct(ApplicationInfo)12057_storage": {
+            "label": "struct TokenStaking.ApplicationInfo",
+            "members": [
+              {
+                "label": "status",
+                "type": "t_enum(ApplicationStatus)12019"
+              },
+              {
+                "label": "panicButton",
+                "type": "t_address"
+              }
+            ]
+          },
+          "t_enum(ApplicationStatus)12019": {
+            "label": "enum TokenStaking.ApplicationStatus",
+            "members": [
+              "NOT_APPROVED",
+              "APPROVED",
+              "PAUSED",
+              "DISABLED"
+            ]
+          },
+          "t_array(t_struct(SlashingEvent)12062_storage)dyn_storage": {
+            "label": "struct TokenStaking.SlashingEvent[]"
+          },
+          "t_struct(SlashingEvent)12062_storage": {
+            "label": "struct TokenStaking.SlashingEvent",
+            "members": [
+              {
+                "label": "stakingProvider",
+                "type": "t_address"
+              },
+              {
+                "label": "amount",
+                "type": "t_uint96"
+              }
+            ]
+          },
+          "t_mapping(t_address,t_address)": {
+            "label": "mapping(address => address)"
+          },
+          "t_mapping(t_address,t_array(t_uint128)dyn_storage)": {
+            "label": "mapping(address => uint128[])"
+          },
+          "t_array(t_uint128)dyn_storage": {
+            "label": "uint128[]"
+          },
+          "t_uint128": {
+            "label": "uint128"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add a .gitignore exception for unknown-11155111.json so the OpenZeppelin manifest is versioned like mainnet layout history, avoiding "Manifest not found" on fresh clones when running Sepolia upgrades.