### PR TITLE
fix(deploy): make published scripts compatible with ethers v5/v6 and replay

### DIFF
--- a/.github/workflows/deploy-consumers.yml
+++ b/.github/workflows/deploy-consumers.yml
@@ -1,0 +1,31 @@
+name: Published deployment consumers
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-and-replay:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        ethers: [5, 6]
+    steps:
+      - uses: actions/checkout@v4
+      # The unchanged producer lockfile uses Hardhat 2.10 and supports Node 18.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18.20.8"
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn build && yarn prepack
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.23.1"
+      - name: Test packed exports on ethers ${{ matrix.ethers }}
+        run: node tests/deploy-consumer/prepare.js ${{ matrix.ethers }}

--- a/.github/workflows/deploy-consumers.yml
+++ b/.github/workflows/deploy-consumers.yml
@@ -17,10 +17,12 @@ jobs:
         ethers: [5, 6]
     steps:
       - uses: actions/checkout@v4
-      # The unchanged producer lockfile uses Hardhat 2.10 and supports Node 18.
+      # Follow the producer's runtime after #182 adds .nvmrc. Until then the
+      # legacy lockfile uses Hardhat 2.10 and is tested on Node 18.
       - uses: actions/setup-node@v4
         with:
-          node-version: "18.20.8"
+          node-version: ${{ hashFiles('.nvmrc') == '' && '18.20.8' || '' }}
+          node-version-file: ${{ hashFiles('.nvmrc') != '' && '.nvmrc' || '' }}
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn build && yarn prepack

--- a/deploy/05_transfer_t.ts
+++ b/deploy/05_transfer_t.ts
@@ -4,8 +4,8 @@ import { DeployFunction } from "hardhat-deploy/types"
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments, helpers } = hre
   const { deployer } = await getNamedAccounts()
-  const { execute } = deployments
-  const { to1e18, from1e18 } = helpers.number
+  const { execute, read, log } = deployments
+  const { from1e18 } = helpers.number
 
   const VendingMachineNuCypher = await deployments.get("VendingMachineNuCypher")
 
@@ -19,20 +19,40 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // There will be 10B T minted on the production environment. The 45% of this
   // amount will go to the KEEP holders, 45% will go to NU holders and 10% will
   // be sent to the DAO treasury.
-  const T_TO_TRANSFER = to1e18("4500000000") // 4.5B T
+  const T_TO_TRANSFER = BigInt("4500000000000000000000000000") // 4.5B T
 
   for (const { tokenSymbol, vendingMachineAddress } of vendingMachines) {
+    const balance = BigInt(
+      (await read("T", "balanceOf", vendingMachineAddress)).toString()
+    )
+    if (balance >= T_TO_TRANSFER) {
+      log(
+        `Vending machine for ${tokenSymbol} is already funded; skipping transfer`
+      )
+      continue
+    }
+
+    const needed = T_TO_TRANSFER - balance
+    const deployerBalance = BigInt(
+      (await read("T", "balanceOf", deployer)).toString()
+    )
+    if (deployerBalance < needed) {
+      throw new Error(
+        `Vending machine for ${tokenSymbol} needs ${needed.toString()} T units, but deployer only has ${deployerBalance.toString()}`
+      )
+    }
+
     await execute(
       "T",
       { from: deployer },
       "transfer",
       vendingMachineAddress,
-      T_TO_TRANSFER
+      needed.toString()
     )
 
     console.log(
       `transferred ${from1e18(
-        T_TO_TRANSFER
+        needed.toString()
       )} T to the VendingMachine for ${tokenSymbol}`
     )
   }

--- a/deploy/07_deploy_token_staking.ts
+++ b/deploy/07_deploy_token_staking.ts
@@ -1,68 +1,75 @@
-import { HardhatRuntimeEnvironment } from "hardhat/types"
-import { DeployFunction } from "hardhat-deploy/types"
+import * as fs from "fs"
 
-import { ethers, upgrades } from "hardhat"
+import type { HardhatRuntimeEnvironment } from "hardhat/types"
+import type { DeployFunction } from "hardhat-deploy/types"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { getNamedAccounts, deployments } = hre
-  const { execute, log } = deployments
+  const { getNamedAccounts, deployments, ethers, upgrades, artifacts } = hre
+  const { execute, read, log } = deployments
   const { deployer } = await getNamedAccounts()
 
   const T = await deployments.get("T")
+  const constructorArgs = [T.address]
+  let tokenStaking = await deployments.getOrNull("TokenStaking")
 
-  const tokenStakingConstructorArgs = [T.address]
-  const tokenStakingInitializerArgs = []
-
-  // TODO: Consider upgradable deployment also for sepolia.
-  let tokenStakingAddress
-  if (hre.network.name == "mainnet") {
-    const TokenStaking = await ethers.getContractFactory("TokenStaking")
-
-    const tokenStaking = await upgrades.deployProxy(
-      TokenStaking,
-      tokenStakingInitializerArgs,
-      {
-        constructorArgs: tokenStakingConstructorArgs,
+  if (!tokenStaking) {
+    // TODO: Consider upgradeable deployment also for sepolia.
+    if (hre.network.name === "mainnet") {
+      const factory = await ethers.getContractFactory(
+        "TokenStaking",
+        await ethers.getSigner(deployer)
+      )
+      const proxy = await upgrades.deployProxy(factory, [], { constructorArgs })
+      // getAddress is v6; v5 contracts expose address instead. Everything after
+      // this boundary uses a hardhat-deploy Deployment, not an ethers contract.
+      const address =
+        typeof proxy.getAddress === "function"
+          ? await proxy.getAddress()
+          : proxy.address
+      const transaction =
+        typeof proxy.deploymentTransaction === "function"
+          ? proxy.deploymentTransaction()
+          : proxy.deployTransaction
+      await transaction.wait()
+      tokenStaking = {
+        address,
+        abi: (await artifacts.readArtifact("TokenStaking")).abi,
+        implementation: await upgrades.erc1967.getImplementationAddress(
+          address
+        ),
       }
-    )
-    tokenStakingAddress = tokenStaking.address
-    log(`Deployed TokenStaking with TransparentProxy at ${tokenStakingAddress}`)
-
-    const implementationInterface = tokenStaking.interface
-    let jsonAbi = implementationInterface.format(ethers.utils.FormatTypes.json)
-
-    const tokenStakingDeployment = {
-      address: tokenStakingAddress,
-      abi: JSON.parse(jsonAbi as string),
+      await deployments.save("TokenStaking", tokenStaking)
+      // Preserve the standalone mainnet export used by deployment operators.
+      fs.writeFileSync(
+        "TokenStaking.json",
+        JSON.stringify(tokenStaking, null, 2)
+      )
+      log(`Deployed TokenStaking with TransparentProxy at ${address}`)
+    } else {
+      tokenStaking = await deployments.deploy("TokenStaking", {
+        from: deployer,
+        args: constructorArgs,
+        log: true,
+      })
     }
-    const fs = require("fs")
-    fs.writeFileSync(
-      "TokenStaking.json",
-      JSON.stringify(tokenStakingDeployment, null, 2),
-      "utf8",
-      function (err) {
-        if (err) {
-          console.log(err)
-        }
-      }
-    )
-    log(`Saved TokenStaking address and ABI in TokenStaking.json`)
-  } else {
-    const TokenStaking = await deployments.deploy("TokenStaking", {
-      from: deployer,
-      args: tokenStakingConstructorArgs,
-      log: true,
-    })
-    tokenStakingAddress = TokenStaking.address
+  }
 
+  // initialize() sets governance. Checking that state also resumes an interrupted
+  // direct deployment whose record was saved before initialization completed.
+  if (
+    (await read("TokenStaking", "governance")) ===
+    "0x0000000000000000000000000000000000000000"
+  ) {
     await execute("TokenStaking", { from: deployer }, "initialize")
     log("Initialized TokenStaking.")
+  } else {
+    log("TokenStaking is already initialized; skipping initialize")
   }
 
   if (hre.network.tags.tenderly) {
     await hre.tenderly.verify({
       name: "TokenStaking",
-      address: tokenStakingAddress,
+      address: tokenStaking.address,
     })
   }
 }

--- a/deploy/30_deploy_tokenholder_timelock.ts
+++ b/deploy/30_deploy_tokenholder_timelock.ts
@@ -1,17 +1,12 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
 
-// FIXME: As a workaround for a bug in hardhat-gas-reporter #86 we import
-// ethers here instead of using the one defined in `hre`.
-// #86: https://github.com/cgewecke/hardhat-gas-reporter/issues/86
-import { ethers } from "ethers"
-
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { getNamedAccounts, deployments } = hre
   const { deployer } = await getNamedAccounts()
 
   const proposers = []
-  const executors = [ethers.constants.AddressZero]
+  const executors = ["0x0000000000000000000000000000000000000000"]
   const minDelay = 172800 // 2 days in seconds (2 * 24 * 60 * 60)
 
   const timelock = await deployments.deploy("TokenholderTimelock", {

--- a/deploy/32_configure_tokenholder_timelock.ts
+++ b/deploy/32_configure_tokenholder_timelock.ts
@@ -7,7 +7,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { execute, read, log } = deployments
 
   const TokenholderGovernor = await deployments.get("TokenholderGovernor")
-  // const TokenholderTimelock = await deployments.get("TokenholderTimelock")
 
   const PROPOSER_ROLE = await read("TokenholderTimelock", "PROPOSER_ROLE")
   const TIMELOCK_ADMIN_ROLE = await read(
@@ -15,23 +14,36 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     "TIMELOCK_ADMIN_ROLE"
   )
 
-  await execute(
-    "TokenholderTimelock",
-    { from: deployer },
-    "grantRole",
-    PROPOSER_ROLE,
-    TokenholderGovernor.address
-  )
-  log(`Granted PROPOSER_ROLE to ${TokenholderGovernor.address}`)
+  if (
+    !(await read(
+      "TokenholderTimelock",
+      "hasRole",
+      PROPOSER_ROLE,
+      TokenholderGovernor.address
+    ))
+  ) {
+    await execute(
+      "TokenholderTimelock",
+      { from: deployer },
+      "grantRole",
+      PROPOSER_ROLE,
+      TokenholderGovernor.address
+    )
+    log(`Granted PROPOSER_ROLE to ${TokenholderGovernor.address}`)
+  }
 
-  await execute(
-    "TokenholderTimelock",
-    { from: deployer },
-    "renounceRole",
-    TIMELOCK_ADMIN_ROLE,
-    deployer
-  )
-  log(`Address ${deployer} renounced to TIMELOCK_ADMIN_ROLE`)
+  if (
+    await read("TokenholderTimelock", "hasRole", TIMELOCK_ADMIN_ROLE, deployer)
+  ) {
+    await execute(
+      "TokenholderTimelock",
+      { from: deployer },
+      "renounceRole",
+      TIMELOCK_ADMIN_ROLE,
+      deployer
+    )
+    log(`Address ${deployer} renounced TIMELOCK_ADMIN_ROLE`)
+  }
 }
 
 export default func

--- a/deploy/52_transfer_ownership_token_staking.ts
+++ b/deploy/52_transfer_ownership_token_staking.ts
@@ -6,6 +6,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer, thresholdCouncil } = await getNamedAccounts()
   const { execute } = deployments
 
+  const currentGovernance = await deployments.read("TokenStaking", "governance")
+  if (currentGovernance.toLowerCase() === thresholdCouncil.toLowerCase()) {
+    return
+  }
+
   await execute(
     "TokenStaking",
     { from: deployer },

--- a/deploy/53_transfer_upgradeability_token_staking.ts
+++ b/deploy/53_transfer_upgradeability_token_staking.ts
@@ -1,12 +1,22 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types"
 import { DeployFunction } from "hardhat-deploy/types"
-import { upgrades } from "hardhat"
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { getNamedAccounts } = hre
-  const { thresholdCouncil } = await getNamedAccounts()
+  const { getNamedAccounts, deployments, ethers, upgrades } = hre
+  const { deployer, thresholdCouncil } = await getNamedAccounts()
 
-  await upgrades.admin.transferProxyAdminOwnership(thresholdCouncil)
+  const TokenStaking = await deployments.get("TokenStaking")
+  const admin = await ethers.getContractAt(
+    [
+      "function owner() view returns (address)",
+      "function transferOwnership(address)",
+    ],
+    await upgrades.erc1967.getAdminAddress(TokenStaking.address),
+    await ethers.getSigner(deployer)
+  )
+  if ((await admin.owner()).toLowerCase() !== thresholdCouncil.toLowerCase()) {
+    await (await admin.transferOwnership(thresholdCouncil)).wait()
+  }
 }
 
 export default func

--- a/tests/deploy-consumer/.eslintrc.json
+++ b/tests/deploy-consumer/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "parserOptions": { "ecmaVersion": 2020 },
+  "env": { "node": true },
+  "rules": { "no-console": "off" }
+}

--- a/tests/deploy-consumer/README.md
+++ b/tests/deploy-consumer/README.md
@@ -1,0 +1,35 @@
+# Published deployment consumer test
+
+The fixture packs the output of `prepack`, installs it into an isolated Hardhat
+project, and executes the unmodified `export/deploy` directory on ethers 5 and 6.
+The producer stays on its existing ethers 5 toolchain. The v5 consumer uses
+hardhat-deploy 0.11.45; the v6 consumer uses hardhat-deploy 1.0.4, hardhat-ethers 3
+and upgrades 2.5.1, matching the downstream stack.
+
+Build using the producer lockfile's supported Node 18 version:
+
+```sh
+yarn install --frozen-lockfile
+yarn build
+yarn prepack
+```
+
+Then use Node 22 for the consumer fixtures:
+
+```sh
+node tests/deploy-consumer/prepare.js 5
+node tests/deploy-consumer/prepare.js 6
+```
+
+An optional second argument selects the temporary consumer directory. No npm
+publication or live-chain transactions occur. Each lane runs both a direct
+TokenStaking deployment and a mainnet-style proxy deployment, using separate
+local deployer and council accounts. The proxy scenario only changes the HRE's
+network name; its provider remains the fresh in-memory Hardhat chain.
+
+Assertions cover vending-machine funding, timelock role membership, initialization,
+proxy admin/governance ownership, saved deployment ABI/address, and unchanged
+addresses and account nonces on replay. Additional checks exercise partial funding,
+overfunding, insufficient funds, and recovery after deployment was interrupted
+before initialization. The consumer compiles the packaged TokenStaking source
+for OpenZeppelin validation; other deployments use the package's exported artifacts.

--- a/tests/deploy-consumer/contracts/Imports.sol
+++ b/tests/deploy-consumer/contracts/Imports.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity 0.8.9;
+
+// Generate consumer-side OpenZeppelin validations from the packaged source.
+import "@threshold-network/solidity-contracts/contracts/staking/TokenStaking.sol";

--- a/tests/deploy-consumer/hardhat.config.js
+++ b/tests/deploy-consumer/hardhat.config.js
@@ -1,0 +1,30 @@
+const path = require("path")
+const major = require("ethers").version.split(".")[0]
+require(major === "6"
+  ? "@nomicfoundation/hardhat-ethers"
+  : "@nomiclabs/hardhat-ethers")
+require("hardhat-deploy")
+require("@keep-network/hardhat-helpers")
+
+module.exports = {
+  solidity: {
+    version: "0.8.9",
+    settings: { optimizer: { enabled: true, runs: 10 } },
+  },
+  networks: { hardhat: { tags: ["allowStubs"] } },
+  namedAccounts: { deployer: 1, thresholdCouncil: 2 },
+  external: {
+    contracts: [
+      {
+        artifacts: path.join(
+          __dirname,
+          "node_modules/@threshold-network/solidity-contracts/export/artifacts"
+        ),
+        deploy: path.join(
+          __dirname,
+          "node_modules/@threshold-network/solidity-contracts/export/deploy"
+        ),
+      },
+    ],
+  },
+}

--- a/tests/deploy-consumer/prepare.js
+++ b/tests/deploy-consumer/prepare.js
@@ -1,0 +1,80 @@
+// Pack the prebuilt publication and exercise it in an independent runtime.
+const fs = require("fs")
+const os = require("os")
+const path = require("path")
+const { execFileSync } = require("child_process")
+
+const major = process.argv[2]
+if (!["5", "6"].includes(major))
+  throw new Error("Usage: node prepare.js 5|6 [directory]")
+const directory = path.resolve(
+  process.argv[3] ||
+    fs.mkdtempSync(path.join(os.tmpdir(), `threshold-deploy-v${major}-`))
+)
+fs.mkdirSync(directory, { recursive: true })
+for (const name of ["hardhat.config.js", "smoke.js", "contracts"]) {
+  fs.cpSync(path.join(__dirname, name), path.join(directory, name), {
+    recursive: true,
+  })
+}
+const packed = JSON.parse(
+  execFileSync(
+    "npm",
+    ["pack", "--ignore-scripts", "--json", "--pack-destination", directory],
+    {
+      cwd: path.join(__dirname, "../.."),
+      encoding: "utf8",
+    }
+  )
+)[0]
+const dependencies = {
+  hardhat: "2.29.0",
+  "hardhat-deploy": major === "5" ? "0.11.45" : "1.0.4",
+  ethers: major === "5" ? "5.8.0" : "6.17.0",
+  "@keep-network/hardhat-helpers": major === "5" ? "0.6.0-pre.15" : "0.7.2",
+  "@openzeppelin/hardhat-upgrades": major === "5" ? "1.28.0" : "2.5.1",
+  "@threshold-network/solidity-contracts": `file:./${packed.filename}`,
+  "fs-extra": "11.2.0",
+  ...(major === "5"
+    ? {
+        "@nomiclabs/hardhat-ethers": "2.2.3",
+        "@nomiclabs/hardhat-etherscan": "3.1.8",
+      }
+    : {
+        "@nomicfoundation/hardhat-ethers": "3.1.0",
+        "@nomicfoundation/hardhat-verify": "2.1.3",
+        "@nomicfoundation/hardhat-network-helpers": "1.1.2",
+      }),
+}
+fs.writeFileSync(
+  path.join(directory, "package.json"),
+  JSON.stringify(
+    {
+      name: `threshold-deploy-consumer-v${major}`,
+      private: true,
+      dependencies,
+    },
+    null,
+    2
+  )
+)
+// helpers 0.7 advertises upgrades 3; deliberately cover the consumer's upgrades
+// 2.x stack too. These scripts use HRE upgrades directly, not helpers.deployProxy.
+execFileSync(
+  "npm",
+  [
+    "install",
+    "--ignore-scripts",
+    "--legacy-peer-deps",
+    "--no-audit",
+    "--no-fund",
+  ],
+  { cwd: directory, stdio: "inherit" }
+)
+for (const mode of ["direct", "proxy"]) {
+  execFileSync("npx", ["--no-install", "hardhat", "run", "smoke.js"], {
+    cwd: directory,
+    stdio: "inherit",
+    env: { ...process.env, DEPLOY_CONSUMER_MODE: mode },
+  })
+}

--- a/tests/deploy-consumer/smoke.js
+++ b/tests/deploy-consumer/smoke.js
@@ -1,0 +1,155 @@
+const assert = require("assert/strict")
+const fs = require("fs")
+const path = require("path")
+const hre = require("hardhat")
+const root = path.dirname(
+  require.resolve("@threshold-network/solidity-contracts/package.json")
+)
+const script = (file) => require(path.join(root, "export/deploy", file)).default
+const target = BigInt("4500000000000000000000000000")
+const sameAddress = (actual, expected) =>
+  assert.equal(actual.toLowerCase(), expected.toLowerCase())
+
+async function main() {
+  const { deployments, getNamedAccounts, network, upgrades, ethers } = hre
+  // Exercise the mainnet-only proxy and ownership scripts on the local in-memory
+  // provider. No RPC URL or live-network credentials are used by this fixture.
+  const proxyMode = process.env.DEPLOY_CONSUMER_MODE === "proxy"
+  if (proxyMode) network.name = "mainnet"
+  const { deployer, thresholdCouncil } = await getNamedAccounts()
+  const address = async (name) => (await deployments.get(name)).address
+  const read = (name, method, ...args) =>
+    deployments.read(name, method, ...args)
+  const nonces = () =>
+    Promise.all(
+      [deployer, thresholdCouncil].map((account) =>
+        network.provider.send("eth_getTransactionCount", [account, "latest"])
+      )
+    )
+  const options = {
+    resetMemory: false,
+    deletePreviousDeployments: false,
+    writeDeploymentsToFiles: true,
+  }
+  await deployments.run(undefined, {
+    ...options,
+    resetMemory: true,
+    deletePreviousDeployments: true,
+  })
+
+  const machine = await address("VendingMachineNuCypher")
+  const staking = await address("TokenStaking")
+  const governor = await address("TokenholderGovernor")
+  const proposerRole = await read("TokenholderTimelock", "PROPOSER_ROLE")
+  const adminRole = await read("TokenholderTimelock", "TIMELOCK_ADMIN_ROLE")
+  assert.equal(
+    (await read("T", "balanceOf", machine)).toString(),
+    target.toString()
+  )
+  assert(await read("TokenholderTimelock", "hasRole", proposerRole, governor))
+  assert.equal(
+    await read("TokenholderTimelock", "hasRole", adminRole, deployer),
+    false
+  )
+  sameAddress(
+    await read("TokenStaking", "governance"),
+    proxyMode ? thresholdCouncil : deployer
+  )
+  if (proxyMode) {
+    const adminAddress = await upgrades.erc1967.getAdminAddress(staking)
+    const admin = await ethers.getContractAt(
+      ["function owner() view returns (address)"],
+      adminAddress
+    )
+    sameAddress(await admin.owner(), thresholdCouncil)
+    sameAddress(await read("T", "owner"), thresholdCouncil)
+    const standalone = JSON.parse(fs.readFileSync("TokenStaking.json"))
+    sameAddress(standalone.address, staking)
+    assert(Array.isArray(standalone.abi))
+  }
+  const before = await nonces()
+  const addressesBefore = Object.fromEntries(
+    Object.entries(await deployments.all()).map(([name, deployment]) => [
+      name,
+      deployment.address,
+    ])
+  )
+  fs.rmSync(
+    path.join(hre.config.paths.deployments, network.name, ".migrations.json"),
+    { force: true }
+  )
+  await deployments.run(undefined, options)
+  assert.deepEqual(await nonces(), before, "replay sent transactions")
+  assert.deepEqual(
+    Object.fromEntries(
+      Object.entries(await deployments.all()).map(([name, deployment]) => [
+        name,
+        deployment.address,
+      ])
+    ),
+    addressesBefore
+  )
+
+  // Check transfer shortfalls/overfunding at the exported script's I/O boundary.
+  // Bigints ensure amounts stay exact even beyond JavaScript's safe integers.
+  const transfer = script("05_transfer_t.js")
+  let transferred = null
+  const context = (balance, available) => ({
+    ...hre,
+    deployments: {
+      ...deployments,
+      read: async (_name, _method, account) =>
+        (account === machine ? balance : available).toString(),
+      execute: async (_name, _options, method, recipient, amount) => {
+        assert.equal(method, "transfer")
+        sameAddress(recipient, machine)
+        transferred = amount.toString()
+      },
+    },
+  })
+  await transfer(context(target - BigInt(17), BigInt(17)))
+  assert.equal(transferred, "17")
+  transferred = null
+  await transfer(context(target + BigInt(1), BigInt(0)))
+  assert.equal(transferred, null)
+  await assert.rejects(
+    transfer(context(target - BigInt(17), BigInt(16))),
+    /deployer only has/
+  )
+
+  // Recover a direct deployment interrupted before initialize().
+  if (!proxyMode) {
+    const uninitialized = await deployments.deploy(
+      "UninitializedTokenStaking",
+      {
+        contract: "TokenStaking",
+        from: deployer,
+        args: [await address("T")],
+      }
+    )
+    await deployments.save("TokenStaking", uninitialized)
+    await script("07_deploy_token_staking.js")(hre)
+    sameAddress(await read("TokenStaking", "governance"), deployer)
+    const initializedNonce = await nonces()
+    await script("07_deploy_token_staking.js")(hre)
+    assert.deepEqual(await nonces(), initializedNonce)
+  }
+  console.log(
+    `PASS: published exports, ethers ${require("ethers").version}, ${
+      proxyMode ? "proxy + ownership handoff" : "direct"
+    }, fresh deploy + replay + transfer guards`
+  )
+}
+main().then(
+  () => process.exit(0),
+  (error) => {
+    console.error(
+      (error.stack || String(error))
+        .split("\n")
+        .slice(0, 12)
+        .map((line) => line.slice(0, 400))
+        .join("\n")
+    )
+    process.exit(1)
+  }
+)


### PR DESCRIPTION
Consumers replay this package's published deployment scripts after copying existing deployment records. Today that can repeat the 4.5B T transfer, call an already-used initializer, or grant a timelock role after the deployer has relinquished administration. The mainnet proxy path also depends on ethers v5-only contract and Interface APIs.

Use on-chain balances, governance and role membership to skip completed work; fund only the vending-machine shortfall and fail if the deployer cannot cover it. Reuse TokenStaking records, recover an interrupted initialization, and save mainnet proxy addresses/ABI through hardhat-deploy using the consumer's HRE. Make the mainnet governance and proxy-admin handoffs replay-safe too. The producer remains on its existing ethers v5 dependencies.

The CI producer follows `.nvmrc` when available (including #182's Node 22 toolchain) and otherwise retains Node 18 for the legacy lockfile. The new CI consumer matrix installs the actual prepacked tarball on ethers v5 and v6 (hardhat-ethers 3 / upgrades 2.5.1). Each lane runs both direct and mainnet-style proxy deployment on fresh local chains, then replays with distinct deployer/council accounts and asserts unchanged account nonces and deployment addresses. It also checks partial/excess funding, insufficient funds, initializer recovery, saved ABI and ownership handoffs.

Validation: locked producer build and prepack, lint, formatting checks, and all four consumer scenarios pass locally. The full Solidity suite passed in CI. The producer integrated with #182 was also built and prepacked on Node 22; all four packed consumer scenarios passed on ethers 5.8.0 and 6.17.0. Workflow formatting and actionlint pass. No live network or npm publication is involved.

Addresses #184; sibling fix: threshold-network/keep-core#4320. Publishing the package, updating keep-core pins, and removing tbtc-v2's overrides remain release follow-ups.

