### PR TITLE
Upgrade Slither CI to 0.11.6

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -263,20 +263,27 @@ jobs:
 
       - uses: actions/setup-python@v7
         with:
-          python-version: 3.10.8
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: requirements-slither.txt
+
+      - name: Install Slither
+        run: |
+          python -m pip install -r requirements-slither.txt
+          python -m pip check
 
       - name: Install Solidity
         env:
           SOLC_VERSION: 0.8.9 # according to solidity.version in hardhat.config.ts
         run: |
-          pip3 install solc-select
           solc-select install $SOLC_VERSION
           solc-select use $SOLC_VERSION
 
-      - name: Install Slither
-        env:
-          SLITHER_VERSION: 0.8.0
-        run: pip3 install slither-analyzer==$SLITHER_VERSION
+      - name: Show analyzer toolchain
+        run: |
+          python --version
+          python -m pip freeze
+          solc --version
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+.venv-slither/
 
 artifacts/
 build/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .openzeppelin/
+.venv-slither/
 artifacts/
 build/
 cache/

--- a/README.adoc
+++ b/README.adoc
@@ -39,6 +39,37 @@ You can run them by doing:
 yarn test
 ```
 
+=== Static analysis
+
+CI runs https://github.com/crytic/slither[Slither] with Python 3.13 and the
+versions pinned in `requirements-slither.txt`: Slither 0.11.6,
+crytic-compile 0.4.2, and solc-select 1.2.0. To use the same tools locally,
+install Python 3.13 and create an isolated environment:
+
+```
+python3.13 -m venv .venv-slither
+source .venv-slither/bin/activate
+python -m pip install -r requirements-slither.txt
+python -m pip check
+solc-select install 0.8.9
+solc-select use 0.8.9
+yarn install --frozen-lockfile
+slither .
+```
+
+Slither performs a clean Hardhat compilation with the OpenZeppelin upgrades
+plugin enabled. The compiler remains Solidity 0.8.9, and
+`slither.config.json` selects the `build` artifacts directory and the
+repository's existing detector/path exclusions. The command fails on analysis
+errors or any finding that has not been excluded or suppressed.
+
+When upgrading, review the upstream release notes and Python requirements,
+update the three pins together, and repeat the commands above in a fresh
+environment. Run `slither . --warn-unused-ignores` to review obsolete inline
+suppressions; investigate new findings and document any necessary suppression
+at the affected code. Also run `yarn build`, `yarn test`, and `yarn format`.
+CI prints the Python and analyzer tool versions for comparison with local runs.
+
 === Deploy contracts
 
 To deploy all contracts on the given network, please run:

--- a/contracts/governance/Checkpoints.sol
+++ b/contracts/governance/Checkpoints.sol
@@ -43,7 +43,6 @@ abstract contract Checkpoints is IVotesHistory {
     // Reserved storage space in case we need to add more variables,
     // since there are upgradeable contracts that inherit from this one.
     // See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-    // slither-disable-next-line unused-state
     uint256[47] private __gap;
 
     /// @notice Emitted when an account changes their delegate.
@@ -125,7 +124,6 @@ abstract contract Checkpoints is IVotesHistory {
     }
 
     /// @notice Change delegation for `delegator` to `delegatee`.
-    // slither-disable-next-line dead-code
     function delegate(address delegator, address delegatee) internal virtual;
 
     /// @notice Moves voting power from one delegate to another
@@ -139,8 +137,6 @@ abstract contract Checkpoints is IVotesHistory {
     ) internal {
         if (src != dst && amount > 0) {
             if (src != address(0)) {
-                // https://github.com/crytic/slither/issues/960
-                // slither-disable-next-line variable-scope
                 (uint256 oldWeight, uint256 newWeight) = writeCheckpoint(
                     _checkpoints[src],
                     subtract,
@@ -150,8 +146,6 @@ abstract contract Checkpoints is IVotesHistory {
             }
 
             if (dst != address(0)) {
-                // https://github.com/crytic/slither/issues/959
-                // slither-disable-next-line uninitialized-local
                 (uint256 oldWeight, uint256 newWeight) = writeCheckpoint(
                     _checkpoints[dst],
                     add,
@@ -241,7 +235,6 @@ abstract contract Checkpoints is IVotesHistory {
     }
 
     /// @notice Maximum token supply. Defaults to `type(uint96).max` (2^96 - 1)
-    // slither-disable-next-line dead-code
     function maxSupply() internal view virtual returns (uint96) {
         return type(uint96).max;
     }

--- a/contracts/governance/GovernorParameters.sol
+++ b/contracts/governance/GovernorParameters.sol
@@ -187,7 +187,6 @@ abstract contract GovernorParameters is Governor {
 
     /// @notice Compute the past total voting power at a particular block
     /// @param blockNumber The block number to get the vote power at
-    // slither-disable-next-line dead-code
     function _getPastTotalSupply(uint256 blockNumber)
         internal
         view

--- a/contracts/staking/TokenStaking.sol
+++ b/contracts/staking/TokenStaking.sol
@@ -105,7 +105,6 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     mapping(address => ApplicationInfo) public applicationInfo;
     address[] public applications;
 
-    // slither-disable-next-line constable-states
     SlashingEvent[] private legacySlashingQueue;
     // slither-disable-next-line constable-states
     uint256 private legacySlashingQueueIndex;
@@ -166,6 +165,8 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     );
     event NotificationRewardSet(uint96 reward);
     event NotificationRewardPushed(uint96 reward);
+    // Preserve the existing event indexing for ABI and log compatibility.
+    // slither-disable-next-line unindexed-event-address
     event NotificationRewardWithdrawn(address recipient, uint96 amount);
     event NotifierRewarded(address indexed notifier, uint256 amount);
     event SlashingProcessed(
@@ -173,7 +174,11 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         uint256 count,
         uint256 tAmount
     );
+    // Preserve the existing event indexing for ABI and log compatibility.
+    // slither-disable-next-line unindexed-event-address
     event GovernanceTransferred(address oldGovernance, address newGovernance);
+    // Preserve the existing event indexing for ABI and log compatibility.
+    // slither-disable-next-line unindexed-event-address
     event NotificationReceived(
         uint96 amount,
         uint256 rewardMultipier,
@@ -195,7 +200,6 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     }
 
     modifier onlyAuthorizerOf(address stakingProvider) {
-        //slither-disable-next-line incorrect-equality
         require(
             stakingProviders[stakingProvider].authorizer == msg.sender,
             "Not authorizer"
@@ -204,7 +208,6 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     }
 
     modifier onlyOwnerOrStakingProvider(address stakingProvider) {
-        //slither-disable-next-line incorrect-equality
         require(
             stakingProviders[stakingProvider].owner != address(0) &&
                 (stakingProvider == msg.sender ||
@@ -215,7 +218,6 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
     }
 
     modifier onlyOwnerOf(address stakingProvider) {
-        // slither-disable-next-line incorrect-equality
         require(
             stakingProviders[stakingProvider].owner == msg.sender,
             "Caller is not owner"
@@ -883,7 +885,6 @@ contract TokenStaking is Initializable, IStaking, Checkpoints {
         emit GovernanceTransferred(oldGuvnor, newGuvnor);
     }
 
-    // slither-disable-next-line dead-code
     function skipApplication(address application)
         internal
         view

--- a/contracts/test/TokenStakingTestSet.sol
+++ b/contracts/test/TokenStakingTestSet.sol
@@ -131,7 +131,6 @@ contract ExpensiveApplicationMock is ApplicationMock {
 contract ManagedGrantMock {
     address public grantee;
 
-    //slither-disable-next-line missing-zero-check
     function setGrantee(address _grantee) external {
         grantee = _grantee;
     }

--- a/contracts/token/T.sol
+++ b/contracts/token/T.sol
@@ -93,7 +93,6 @@ contract T is ERC20WithPermit, MisfundRecovery, Checkpoints {
         return delegate(msg.sender, delegatee);
     }
 
-    // slither-disable-next-line dead-code
     function beforeTokenTransfer(
         address from,
         address to,

--- a/contracts/utils/SafeTUpgradeable.sol
+++ b/contracts/utils/SafeTUpgradeable.sol
@@ -47,6 +47,9 @@ library SafeTUpgradeable {
         address to,
         uint256 value
     ) internal {
+        // This internal adapter relies on callers to authenticate `from`.
+        // Its only callers, in TokenStakingTestSet, pass msg.sender.
+        // slither-disable-next-line arbitrary-send-erc20
         SafeERC20Upgradeable.safeTransferFrom(
             IERC20Upgradeable(address(token)),
             from,

--- a/requirements-slither.txt
+++ b/requirements-slither.txt
@@ -1,0 +1,4 @@
+# Keep the analyzer and its compilation tools in sync with the tested CI setup.
+slither-analyzer==0.11.6
+crytic-compile==0.4.2
+solc-select==1.2.0


### PR DESCRIPTION
Closes #187.

Upgrade CI from Slither 0.8.0 to [0.11.6](https://github.com/crytic/slither/releases/tag/0.11.6), with crytic-compile 0.4.2 and solc-select 1.2.0 pinned in `requirements-slither.txt`. The job uses Python 3.13, checks Python dependency consistency, and logs the resolved toolchain. The README includes local setup and an upgrade procedure. The documented `.venv-slither/` is excluded from both Git and Prettier, so formatting commands skip installed Python dependencies.

This PR is stacked on #182 (`chore/dependency-toolchain-refresh`, base `14843ac`). Merge #182 first, then retarget this PR to `main`. It uses that PR's Node 22 / Hardhat 2 / Ethers 5 toolchain.

Slither completes with the OpenZeppelin upgrades plugin enabled, resolving the historical crash that blocked #96. All Solidity edits are comments: remove 13 obsolete suppressions and document four narrowly scoped suppressions. The internal `SafeTUpgradeable.safeTransferFrom` adapter's two callers pass `msg.sender`; the three unindexed-event notices retain the existing event ABI and log encoding. Existing detector/path exclusions and the default failure policy are preserved.

Validation:

- Fresh `yarn install --frozen-lockfile` and `python -m pip check` pass.
- `slither .` performs a clean compilation and finishes with **0 findings across 84 contracts and 95 detectors**.
- `yarn build`, `yarn test` (**380 passing**), and `yarn format` (including type checking) pass.
- All 25 repository-owned deployable artifacts retain identical ABIs, link references, and creation/runtime bytecode excluding compiler metadata. Solidity remains at 0.8.9.
- Isolated gate checks confirm an unsuppressed informational finding exits 255 and invalid Solidity exits 1.
- actionlint 1.7.12 and `git diff --check` pass.
- The optional unused-ignore audit now reports only the existing dependency directive in `node_modules/@thesis/solidity-contracts/contracts/token/ERC20WithPermit.sol` (reported twice); repository-owned directives are clean.

Local runtime: Python 3.13.7, Node 22.23.1, Yarn 1.22.22. CI used Python 3.13.15 and confirmed 0 Slither findings, compilation of 75 Solidity files, and 380 passing tests.

GitHub Actions passed on `20a20d5`: [Solidity build/tests, Slither, and deployment dry run](https://github.com/threshold-network/solidity-contracts/actions/runs/34284129152), [formatting and type checks](https://github.com/threshold-network/solidity-contracts/actions/runs/34284129155), and [documentation preview](https://github.com/threshold-network/solidity-contracts/actions/runs/34284129431).
