### PR TITLE
Fix delegation ordering in token burn tests

### DIFF
--- a/test/token/T.test.js
+++ b/test/token/T.test.js
@@ -842,7 +842,7 @@ describe("T token", () => {
       let tx
 
       beforeEach(async () => {
-        t.connect(tokenHolder).delegate(delegatee.address)
+        await t.connect(tokenHolder).delegate(delegatee.address)
         tx = await doBurn(tokenHolder, amount)
       })
 
@@ -869,7 +869,7 @@ describe("T token", () => {
       let tx
 
       beforeEach(async () => {
-        t.connect(tokenHolder).delegate(tokenHolder.address)
+        await t.connect(tokenHolder).delegate(tokenHolder.address)
         tx = await doBurn(tokenHolder, amount)
       })
 


### PR DESCRIPTION
The shared burn-test setup started delegation without awaiting it, allowing `burn` or `burnFrom` to execute before voting power was delegated. Await both delegation calls so the existing event assertions observe the intended ordering.

Closes #111.

Validation: all 106 token tests pass on the existing Hardhat 2.10 / ethers 5 stack. A temporary timing harness delayed delegation submission by 100 ms: all four affected event tests failed with the original code and all four passed with this fix. Modified-file ESLint, Prettier, and `git diff --check` pass. Gas reporting was disabled locally because its reporter requires a listening socket in the sandbox; the contract tests ran on the in-memory Hardhat network.
