### PR TITLE
Use supported Etherscan verification for maintained deployments

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -151,11 +151,12 @@ jobs:
       - name: Upload files needed for etherscan verification
         uses: actions/upload-artifact@v7
         with:
-          name: Artifacts for etherscan verifcation
+          name: Artifacts for etherscan verification
           # hardhat-deploy requires the hidden .chainId deployment marker.
           include-hidden-files: true
           path: |
             ./deployments
+            ./build
             ./package.json
             ./yarn.lock
 
@@ -168,7 +169,7 @@ jobs:
       - name: Download files needed for etherscan verification
         uses: actions/download-artifact@v8
         with:
-          name: Artifacts for etherscan verifcation
+          name: Artifacts for etherscan verification
 
       - uses: actions/setup-node@v7
         with:
@@ -184,7 +185,7 @@ jobs:
           CHAIN_API_URL: ${{ secrets.SEPOLIA_ETH_HOSTNAME_HTTP }}
         run: |
           yarn run hardhat --network ${{ github.event.inputs.environment }} \
-            etherscan-verify --license GPL-3.0 --force-license
+            verify-deployments
 
   # This job is responsible for publishing packages from `dapp-development`
   # branch, which are slightly modified to help with the process of testing some

--- a/README.adoc
+++ b/README.adoc
@@ -49,3 +49,6 @@ yarn deploy --network <network>
 If contracts haven't been built yet or changes occurred, this task will build
 the contracts before running the deployment script. This command produces
 an `export.json` file containing contract deployment info.
+
+See link:docs/verification.adoc[deployment verification] for verifying maintained
+contracts on Etherscan using the saved deployment records.

--- a/docs/verification.adoc
+++ b/docs/verification.adoc
@@ -1,0 +1,76 @@
+= Deployment verification
+
+The repository uses `@nomicfoundation/hardhat-verify` 2.1.3, the Hardhat 2
+release (`hh2`), with the Node 22 / Hardhat 2 / ethers 5 toolchain from #182.
+It uses Etherscan API V2 with one `ETHERSCAN_API_KEY` for Ethereum mainnet
+(chain ID 1) and Sepolia (11155111).
+
+== Maintained deployment scope
+
+`verify-deployments` verifies these hardhat-deploy records on either network:
+
+[cols="1,2"]
+|===
+|Deployment |Solidity contract
+|`T` |`contracts/token/T.sol:T`
+|`VendingMachineNuCypher` |`contracts/vending/VendingMachine.sol:VendingMachine`
+|`TokenholderTimelock` |`@openzeppelin/contracts/governance/TimelockController.sol:TimelockController`
+|`TokenholderGovernor` |`contracts/governance/TokenholderGovernor.sol:TokenholderGovernor`
+|===
+
+These are the non-staking contracts emitted by the current deployment scripts.
+TokenStaking and its associated proxy are excluded following their mainnet
+retirement, as clarified in #185. External NuCypher deployments and local test
+stubs are also excluded. The task does not reconcile historical staking records.
+
+== Commands
+
+Use the source revision, dependencies, compiler settings, and deployment records
+from the deployment being verified. Historical deployments can require their
+historical source revision; current sources are not a replacement for it.
+
+[source,bash]
+----
+yarn install --frozen-lockfile
+yarn build
+# Set CHAIN_API_URL and ETHERSCAN_API_KEY in your environment.
+yarn hardhat verify-deployments --network sepolia
+# Verify only selected records:
+yarn hardhat verify-deployments --network sepolia T VendingMachineNuCypher
+# The same task supports --network mainnet with a mainnet RPC URL.
+----
+
+Verification requires no account private key and sends no blockchain
+transactions. It submits contract sources to the public explorer. Restore
+`deployments/<network>/`, including `.chainId`, and matching `build/` artifacts
+from the deployment run. For CI deployments these are transferred together to
+the verification job. Constructor arguments and linked libraries are read from
+the saved records; the task never recomputes them from today's named accounts or
+configuration and does not modify those records.
+
+Missing records or constructor arguments fail before any submission. Unsupported
+deployment names fail explicitly. Already verified contracts are handled by the
+plugin; other errors fail the command and CI. Source SPDX identifiers supply
+licensing information in the compiler input, replacing the old blanket
+`--license GPL-3.0 --force-license` flags.
+
+For an individual contract outside the batch, the plugin also provides:
+
+[source,bash]
+----
+yarn hardhat verify --network sepolia --contract contracts/token/T.sol:T <address>
+----
+
+See the https://v2.hardhat.org/hardhat-runner/plugins/nomicfoundation-hardhat-verify[Hardhat 2 verification documentation]
+for constructor argument files and additional plugin options.
+
+== Retained upgrade tooling
+
+`@openzeppelin/hardhat-upgrades` remains installed. `deploy/07_deploy_token_staking.ts`
+uses `deployProxy`, `deploy/53_transfer_upgradeability_token_staking.ts` transfers
+proxy administration, and the staking and proxy-admin test suites use proxy
+deployment and upgrade helpers. Pending #176 and #186 also retain consumer and
+Sepolia proxy workflows. Retiring the mainnet staking verification target does
+not remove these uses. The new plugin does not provide the old upgrades 1.x
+automatic proxy-verification extension; future Sepolia proxy verification must
+be handled with its matching implementation and proxy metadata.

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -5,6 +5,7 @@ import "@keep-network/hardhat-helpers"
 import "@nomiclabs/hardhat-ethers"
 import "@nomicfoundation/hardhat-chai-matchers"
 import "@openzeppelin/hardhat-upgrades"
+import "@nomicfoundation/hardhat-verify"
 import { Tenderly } from "@tenderly/hardhat-tenderly/dist/Tenderly"
 import "@tenderly/hardhat-tenderly/dist/type-extensions"
 
@@ -12,6 +13,7 @@ import "hardhat-contract-sizer"
 import "hardhat-deploy"
 import "hardhat-gas-reporter"
 import "solidity-docgen"
+import "./tasks/verify-deployments"
 
 // Tenderly 1.8's public setup() registers one module-scope extendEnvironment
 // (which fetches the network catalog via populateNetworks() on every hardhat
@@ -84,10 +86,11 @@ const config: HardhatUserConfig = {
     username: "thesis",
     project: "thesis/threshold-network",
   },
-  verify: {
-    etherscan: {
-      apiKey: process.env.ETHERSCAN_API_KEY,
-    },
+  etherscan: {
+    apiKey: process.env.ETHERSCAN_API_KEY || "",
+  },
+  sourcify: {
+    enabled: false,
   },
   external: {
     deployments: {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@keep-network/hardhat-helpers": "^0.6.0-pre.21",
     "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep#d6ec02e",
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
+    "@nomicfoundation/hardhat-verify": "2.1.3",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@openzeppelin/hardhat-upgrades": "^1.28.0",
     "@tenderly/hardhat-tenderly": "1.8.0",

--- a/tasks/verify-deployments.ts
+++ b/tasks/verify-deployments.ts
@@ -1,0 +1,53 @@
+import { task } from "hardhat/config"
+
+// Contracts still deployed by this repository. TokenStaking and its proxy are
+// retired on mainnet; external NU contracts and local stubs are not ours to verify.
+export const verificationContracts: Record<string, string> = {
+  T: "contracts/token/T.sol:T",
+  VendingMachineNuCypher: "contracts/vending/VendingMachine.sol:VendingMachine",
+  TokenholderTimelock:
+    "@openzeppelin/contracts/governance/TimelockController.sol:TimelockController",
+  TokenholderGovernor:
+    "contracts/governance/TokenholderGovernor.sol:TokenholderGovernor",
+}
+
+task("verify-deployments", "Verify maintained deployments on Etherscan")
+  .addOptionalVariadicPositionalParam(
+    "names",
+    "Deployment names to verify (defaults to all maintained contracts)",
+    Object.keys(verificationContracts)
+  )
+  .setAction(async ({ names }: { names: string[] }, hre) => {
+    if (!["mainnet", "sepolia"].includes(hre.network.name)) {
+      throw new Error("Verification is supported on mainnet and sepolia")
+    }
+
+    // Resolve the entire request first, before making any explorer submissions.
+    const requests = await Promise.all(
+      names.map(async (name) => {
+        if (
+          !Object.prototype.hasOwnProperty.call(verificationContracts, name)
+        ) {
+          throw new Error(`Unsupported verification deployment: ${name}`)
+        }
+        const deployment = await hre.deployments.get(name)
+        if (!Array.isArray(deployment.args)) {
+          throw new Error(`Missing constructor arguments for ${name}`)
+        }
+        return {
+          name,
+          address: deployment.address,
+          constructorArguments: deployment.args,
+          libraries: deployment.libraries || {},
+          contract: verificationContracts[name],
+        }
+      })
+    )
+
+    for (const { name, ...request } of requests) {
+      console.log(`Verifying ${name} at ${request.address}`)
+      // The supported plugin handles already-verified contracts. Other failures
+      // propagate to the CLI/CI; never turn a rejected submission into success.
+      await hre.run("verify:verify", request)
+    }
+  })

--- a/test/verification.test.js
+++ b/test/verification.test.js
@@ -1,0 +1,178 @@
+const { expect } = require("chai")
+const hre = require("hardhat")
+const { verificationContracts } = require("../tasks/verify-deployments")
+const { Etherscan } = require("@nomicfoundation/hardhat-verify/etherscan")
+
+describe("deployment verification", () => {
+  const action = hre.tasks["verify-deployments"].action
+  const names = Object.keys(verificationContracts)
+  let requests
+  let records
+  let context
+
+  beforeEach(() => {
+    requests = []
+    // Committed records exercise the real aliases, nested constructor arrays,
+    // large allocation amounts, and legacy governance constructor arguments.
+    records = Object.fromEntries(
+      names.map((name) => [
+        name,
+        require(`../deployments/mainnet/${name}.json`),
+      ])
+    )
+    context = {
+      network: { name: "sepolia" },
+      deployments: {
+        get: async (name) => {
+          if (!records[name])
+            throw new Error(`No deployment found for: ${name}`)
+          return records[name]
+        },
+      },
+      run: async (task, args) => requests.push({ task, args }),
+    }
+  })
+
+  it("verifies maintained records with their exact constructor arguments", async () => {
+    await action({ names }, context)
+    expect(requests).to.have.length(4)
+    for (const [index, name] of names.entries()) {
+      expect(requests[index]).to.deep.equal({
+        task: "verify:verify",
+        args: {
+          address: records[name].address,
+          constructorArguments: records[name].args,
+          libraries: records[name].libraries || {},
+          contract: verificationContracts[name],
+        },
+      })
+      await hre.artifacts.readArtifact(verificationContracts[name])
+    }
+  })
+
+  it("supports selecting one deployment and preserves linked libraries", async () => {
+    context.network.name = "mainnet"
+    records.T = Object.assign({}, records.T, {
+      libraries: { Library: records.T.address },
+    })
+    await action({ names: ["T"] }, context)
+    expect(requests).to.have.length(1)
+    expect(requests[0].args.libraries).to.deep.equal(records.T.libraries)
+  })
+
+  it("does not verify retired staking, its proxy, or external contracts", async () => {
+    for (const name of ["TokenStaking", "TokenStakingProxy", "NuCypherToken"]) {
+      await expect(action({ names: ["T", name] }, context)).to.be.rejectedWith(
+        `Unsupported verification deployment: ${name}`
+      )
+    }
+    expect(requests).to.have.length(0)
+  })
+
+  it("fails before submitting anything if a requested deployment is missing", async () => {
+    delete records.TokenholderGovernor
+    await expect(action({ names }, context)).to.be.rejectedWith(
+      "No deployment found for: TokenholderGovernor"
+    )
+    expect(requests).to.have.length(0)
+  })
+
+  it("rejects missing constructor metadata instead of guessing empty arguments", async () => {
+    records.TokenholderTimelock = Object.assign(
+      {},
+      records.TokenholderTimelock,
+      {
+        args: undefined,
+      }
+    )
+    await expect(action({ names }, context)).to.be.rejectedWith(
+      "Missing constructor arguments for TokenholderTimelock"
+    )
+    expect(requests).to.have.length(0)
+  })
+
+  it("propagates explorer failures to CI", async () => {
+    context.run = async () => {
+      throw new Error("Explorer rejected the source")
+    }
+    await expect(action({ names: ["T"] }, context)).to.be.rejectedWith(
+      "Explorer rejected the source"
+    )
+  })
+
+  it("rejects local networks", async () => {
+    context.network.name = "hardhat"
+    await expect(action({ names }, context)).to.be.rejectedWith(
+      "Verification is supported on mainnet and sepolia"
+    )
+    expect(requests).to.have.length(0)
+  })
+
+  it("matches fresh deployments through the real plugin and skips verified replays", async () => {
+    await hre.deployments.fixture()
+    const [deployer] = await hre.ethers.getSigners()
+    const nonce = await deployer.getTransactionCount()
+    const originalConfig = hre.config.etherscan
+    const originalMethods = {
+      isVerified: Etherscan.prototype.isVerified,
+      verify: Etherscan.prototype.verify,
+      getVerificationStatus: Etherscan.prototype.getVerificationStatus,
+    }
+    const submissions = []
+    const verified = new Set()
+    try {
+      hre.config.etherscan = Object.assign({}, originalConfig, {
+        apiKey: "local-test-key",
+        customChains: [
+          {
+            network: "hardhat",
+            chainId: 31337,
+            urls: {
+              apiURL: "https://api.etherscan.io/v2/api",
+              browserURL: "https://sepolia.etherscan.io",
+            },
+          },
+        ],
+      })
+      // Stub only the explorer boundary. Bytecode matching, source selection,
+      // constructor encoding, and task dispatch use the installed plugin.
+      Etherscan.prototype.isVerified = async (address) => verified.has(address)
+      Etherscan.prototype.verify = async function (...args) {
+        expect(this.apiUrl).to.equal("https://api.etherscan.io/v2/api")
+        submissions.push(args)
+        return { message: args[0] }
+      }
+      Etherscan.prototype.getVerificationStatus = async (address) => {
+        verified.add(address)
+        return {
+          isAlreadyVerified: () => false,
+          isFailure: () => false,
+          isSuccess: () => true,
+        }
+      }
+      context.deployments = hre.deployments
+      context.run = hre.run
+      await action({ names }, context)
+      expect(submissions).to.have.length(4)
+      for (const [index, name] of names.entries()) {
+        const deployment = await hre.deployments.get(name)
+        const [address, source, contract, compiler, args] = submissions[index]
+        expect(address).to.equal(deployment.address)
+        expect(contract).to.equal(verificationContracts[name])
+        expect(compiler).to.equal("v0.8.9+commit.e5eed63a")
+        expect(JSON.parse(source).language).to.equal("Solidity")
+        expect(args).to.equal(
+          new hre.ethers.utils.Interface(deployment.abi)
+            .encodeDeploy(deployment.args)
+            .slice(2)
+        )
+      }
+      await action({ names }, context)
+      expect(submissions).to.have.length(4)
+      expect(await deployer.getTransactionCount()).to.equal(nonce)
+    } finally {
+      hre.config.etherscan = originalConfig
+      Object.assign(Etherscan.prototype, originalMethods)
+    }
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -155,7 +155,7 @@
     "@ethersproject/logger" "^5.8.0"
     "@ethersproject/properties" "^5.8.0"
 
-"@ethersproject/address@5.8.0", "@ethersproject/address@^5.7.0", "@ethersproject/address@^5.8.0":
+"@ethersproject/address@5.8.0", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.7.0", "@ethersproject/address@^5.8.0":
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.8.0.tgz#3007a2c352eee566ad745dca1dbbebdb50a6a983"
   integrity sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==
@@ -641,6 +641,21 @@
     chai-as-promised "^7.1.1"
     deep-eql "^4.0.1"
     ordinal "^1.0.3"
+
+"@nomicfoundation/hardhat-verify@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.1.3.tgz#f61a192a792b39f9978cef1450047deaff3ea052"
+  integrity sha512-danbGjPp2WBhLkJdQy9/ARM3WQIK+7vwzE0urNem1qZJjh9f54Kf5f1xuQv8DvqewUAkuPxVt/7q4Grz5WjqSg==
+  dependencies:
+    "@ethersproject/abi" "^5.1.2"
+    "@ethersproject/address" "^5.0.2"
+    cbor "^8.1.0"
+    debug "^4.1.1"
+    lodash.clonedeep "^4.5.0"
+    picocolors "^1.1.0"
+    semver "^6.3.0"
+    table "^6.8.0"
+    undici "^5.14.0"
 
 "@nomicfoundation/slang@^0.18.3":
   version "0.18.3"
@@ -1509,6 +1524,13 @@ cbor@^10.0.0:
   integrity sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==
   dependencies:
     nofilter "^3.0.2"
+
+cbor@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/cbor/-/cbor-8.1.0.tgz#cfc56437e770b73417a2ecbfc9caf6b771af60d5"
+  integrity sha512-DwGjNW9omn6EwP70aXsn7FQJx5kO12tX0bZkaTjzdVFM6/7nhA4t0EENocKGx6D2Bch9PE2KzCUf5SceBdeijg==
+  dependencies:
+    nofilter "^3.1.0"
 
 chai-as-promised@^7.1.1:
   version "7.1.2"
@@ -3059,6 +3081,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash.clonedeep@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
+  integrity sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -3326,7 +3353,7 @@ node-gyp-build@^4.2.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
   integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
-nofilter@^3.0.2:
+nofilter@^3.0.2, nofilter@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-3.1.0.tgz#c757ba68801d41ff930ba2ec55bab52ca184aa66"
   integrity sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==
@@ -4120,7 +4147,7 @@ supports-color@^8.1.1:
   dependencies:
     has-flag "^4.0.0"
 
-table@^6.0.9, table@^6.8.1:
+table@^6.0.9, table@^6.8.0, table@^6.8.1:
   version "6.9.0"
   resolved "https://registry.yarnpkg.com/table/-/table-6.9.0.tgz#50040afa6264141c7566b3b81d4d82c47a8668f5"
   integrity sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==


### PR DESCRIPTION
Replace hardhat-deploy's legacy `etherscan-verify` CI task with `@nomicfoundation/hardhat-verify` 2.1.3, the supported `hh2` release. Configure a single Etherscan API V2 key and verify the four non-staking deployment records emitted by the current scripts: T, VendingMachineNuCypher, TokenholderTimelock, and TokenholderGovernor on mainnet or Sepolia.

The new `verify-deployments` task reads saved addresses, constructor arguments, and linked libraries, including the VendingMachine and TimelockController aliases. It rejects missing records/arguments before submission, lets the plugin skip already-verified contracts, and propagates verification failures to CI. CI transfers compiler artifacts with the deployment records. Documentation covers commands, scope, historical source requirements, and the retained upgrades dependency.

TokenStaking/proxy verification is excluded per #185. The OpenZeppelin upgrades plugin remains because deployment scripts and proxy/staking tests still use it; #176 and #186 also retain consumer/testnet proxy behavior.

This PR is stacked on #182 (`chore/dependency-toolchain-refresh`, base `14843ac`). Merge #182 first, then retarget to `main`. Refs #185; supersedes the deprecated-plugin approach in #125.

Validation:

- Frozen install, build, type checking, lint/formatting, prepack, actionlint, and `git diff --check` pass.
- Full suite: **388 passing**, including eight new verification tests. The real plugin matches four fresh local deployments, encodes their actual constructor arguments, and handles replay without another submission or blockchain transaction. Only explorer responses are stubbed.
- Read-only preflight against existing Sepolia T at [0x4f261630173D2FA1e2b081c460636DE9672B7149](https://sepolia.etherscan.io/address/0x4f261630173D2FA1e2b081c460636DE9672B7149#code) confirmed chain ID 11155111, a bytecode match for `contracts/token/T.sol:T`, compiler `0.8.9+commit.e5eed63a`, and the empty constructor argument list.

A live Etherscan submission was not performed: no `ETHERSCAN_API_KEY` is available in this session. That final authenticated verification check remains for the configured CI environment; the issue should remain open until it succeeds. No public-network deployment or npm publication was performed.
