### PR TITLE
Use Threshold-owned CI and release actions

### DIFF
--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -16,9 +16,9 @@ jobs:
     outputs:
       path-filter: ${{ steps.filter.outputs.path-filter }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -39,7 +39,7 @@ jobs:
       needs.docs-detect-changes.outputs.path-filter == 'true'
         || github.event_name == 'push'
         || github.event_name == 'workflow_dispatch'
-    uses: keep-network/ci/.github/workflows/reusable-solidity-docs.yml@main
+    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
     with:
       publish: false
       addTOC: false
@@ -56,7 +56,7 @@ jobs:
     name: Publish contracts documentation
     needs: docs-detect-changes
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
-    uses: keep-network/ci/.github/workflows/reusable-solidity-docs.yml@main
+    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
     with:
       publish: true
       addTOC: false

--- a/.github/workflows/contracts-docs.yml
+++ b/.github/workflows/contracts-docs.yml
@@ -39,8 +39,9 @@ jobs:
       needs.docs-detect-changes.outputs.path-filter == 'true'
         || github.event_name == 'push'
         || github.event_name == 'workflow_dispatch'
-    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@20b35345d276a3c7365e3829b8078387a7c9dccb
     with:
+      nodeVersion: "18.20.8"
       publish: false
       addTOC: false
       commentPR: false
@@ -56,8 +57,9 @@ jobs:
     name: Publish contracts documentation
     needs: docs-detect-changes
     if: github.event_name == 'release' && startsWith(github.ref, 'refs/tags/v')
-    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+    uses: threshold-network/ci/.github/workflows/reusable-solidity-docs.yml@20b35345d276a3c7365e3829b8078387a7c9dccb
     with:
+      nodeVersion: "18.20.8"
       publish: true
       addTOC: false
       verifyCommits: true

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -40,10 +40,10 @@ jobs:
     outputs:
       system-tests: ${{ steps.filter.outputs.system-tests }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: github.event_name == 'pull_request'
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         if: github.event_name == 'pull_request'
         id: filter
         with:
@@ -55,9 +55,9 @@ jobs:
   contracts-build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -78,9 +78,9 @@ jobs:
   contracts-deployment-dry-run:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -101,9 +101,9 @@ jobs:
         && github.ref != 'refs/heads/dapp-development'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -129,7 +129,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           environment: ${{ github.event.inputs.environment }}
           branch: ${{ github.ref }}
@@ -141,7 +141,7 @@ jobs:
         run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@v2
+        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -153,8 +153,9 @@ jobs:
           version: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Upload files needed for etherscan verification
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
+          include-hidden-files: true
           name: Artifacts for etherscan verifcation
           path: |
             ./deployments
@@ -165,14 +166,14 @@ jobs:
     needs: [contracts-deployment-testnet]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Download files needed for etherscan verification
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: Artifacts for etherscan verifcation
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -202,9 +203,9 @@ jobs:
         && github.ref == 'refs/heads/dapp-development'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -225,7 +226,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           environment: dapp-dev-${{ github.event.inputs.environment }}
           branch: ${{ github.ref }}
@@ -240,7 +241,7 @@ jobs:
             --tag dapp-development-${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
-        uses: keep-network/ci/actions/notify-workflow-completed@v2
+        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -257,9 +258,9 @@ jobs:
       github.event_name != 'workflow_dispatch'
         && github.event_name != 'schedule'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 was sometimes causing issues with
           # artifacts generation during `hardhat compile` - see
@@ -267,7 +268,7 @@ jobs:
           node-version: "18.15.0"
           cache: "yarn"
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.10.8
 

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -69,7 +69,9 @@ jobs:
         run: yarn install
 
       - name: Build contracts
-        run: yarn build
+        # The locked OpenZeppelin upgrades plugin can lose validation-cache
+        # entries when independent compilation jobs write concurrently.
+        run: yarn build --concurrency 1
 
       - name: Run tests
         if: github.ref != 'refs/heads/dapp-development'

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           environment: ${{ github.event.inputs.environment }}
           branch: ${{ github.ref }}
@@ -141,7 +141,7 @@ jobs:
         run: npm publish --access=public --network=${{ github.event.inputs.environment }} --tag ${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
@@ -226,7 +226,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           environment: dapp-dev-${{ github.event.inputs.environment }}
           branch: ${{ github.ref }}
@@ -241,7 +241,7 @@ jobs:
             --tag dapp-development-${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
-        uses: threshold-network/ci/actions/notify-workflow-completed@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/notify-workflow-completed@20b35345d276a3c7365e3829b8078387a7c9dccb
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -16,9 +16,9 @@ jobs:
   npm-compile-publish-contracts:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           # Using fixed version, because 18.16 may cause issues with the
           # artifacts generation during `hardhat compile` - see
@@ -37,7 +37,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: keep-network/npm-version-bump@v2
+        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
         with:
           environment: dev
           branch: ${{ github.ref }}

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Bump up package version
         id: npm-version-bump
-        uses: threshold-network/ci/actions/npm-version-bump@4e5a710bc94d6abba62abbb6b8c70adfd10af83f
+        uses: threshold-network/ci/actions/npm-version-bump@20b35345d276a3c7365e3829b8078387a7c9dccb
         with:
           environment: dev
           branch: ${{ github.ref }}


### PR DESCRIPTION
Use the maintained actions from [threshold-network/ci #1](https://github.com/threshold-network/ci/pull/1), pinned to `20b35345d276a3c7365e3829b8078387a7c9dccb`. This includes the vendored npm-version-bump action. Completion payloads and upstream-build queries use the Threshold module identifiers configured by the new release manager.

Update obsolete action runtimes in the affected workflows. Artifact uploads preserve hidden deployment metadata when moving to artifact v4. The producer and all consumer migrations must merge before starting a new inter-repository release pipeline; `CI_GITHUB_TOKEN` must be configured where missing. npm/cloud/docs credentials stay in their existing consumer repositories.

Validation: actionlint passes for every changed workflow; producer paths, input names, commit pins, dispatch input contracts, and module/query identifiers were checked against the producer. Its 51 tests and four standalone action-bundle checks pass in GitHub CI. Release/deployment/publishing paths were not invoked during validation.

The shared docs workflow is now owned and pinned. These changes are independent of the helper and lint-config migrations in #193 and #194.

The docs caller selects Node 18.20.8 because this repository still locks Hardhat 2.10.2; the maintained action runtime remains Node 24. The shared workflow exposes the build Node version as a consumer input.

Serialize the CI build’s compiler jobs (`--concurrency 1`) while the locked OpenZeppelin upgrades plugin remains at 1.14.0. Its validation cache has an unguarded read/merge/write: invoking the installed plugin on three real compiler results concurrently retained only one result and lost `SimpleStorage`; serial writes retained all three. This matches the proxy test failure observed twice in CI. A clean serial build preserves all 84 contract artifact files byte-for-byte and the complete validation cache. All 380 tests pass after the clean serial build. Contract code, compiler settings, and dependency versions are unchanged.
