### PR TITLE
Preserve historical proposal outcomes when quorum changes

### DIFF
--- a/contracts/governance/GovernorParameters.sol
+++ b/contracts/governance/GovernorParameters.sol
@@ -16,6 +16,7 @@
 pragma solidity 0.8.9;
 
 import "@openzeppelin/contracts/governance/Governor.sol";
+import {Checkpoints as QuorumCheckpoints} from "@openzeppelin/contracts/utils/Checkpoints.sol";
 
 /// @title GovernorParameters
 /// @notice Abstract contract to handle governance parameters
@@ -24,6 +25,8 @@ import "@openzeppelin/contracts/governance/Governor.sol";
 ///      thresholds too. See OpenZeppelin's GovernorVotesQuorumFraction,
 ///      GovernorVotes and GovernorSettings for reference.
 abstract contract GovernorParameters is Governor {
+    using QuorumCheckpoints for QuorumCheckpoints.History;
+
     uint256 public constant FRACTION_DENOMINATOR = 10000;
     uint64 internal constant AVERAGE_BLOCK_TIME_IN_SECONDS = 13;
 
@@ -32,6 +35,7 @@ abstract contract GovernorParameters is Governor {
 
     uint256 private _votingDelay;
     uint256 private _votingPeriod;
+    QuorumCheckpoints.History private _quorumNumeratorHistory;
 
     event QuorumNumeratorUpdated(
         uint256 oldQuorumNumerator,
@@ -103,8 +107,10 @@ abstract contract GovernorParameters is Governor {
         override
         returns (uint256)
     {
+        uint256 pastTotalSupply = _getPastTotalSupply(blockNumber);
         return
-            (_getPastTotalSupply(blockNumber) * quorumNumerator) /
+            (pastTotalSupply *
+                _quorumNumeratorHistory.getAtBlock(blockNumber)) /
             FRACTION_DENOMINATOR;
     }
 
@@ -153,7 +159,21 @@ abstract contract GovernorParameters is Governor {
         );
 
         uint256 oldQuorumNumerator = quorumNumerator;
-        quorumNumerator = newQuorumNumerator;
+
+        if (_quorumNumeratorHistory._checkpoints.length == 0) {
+            // Preserve the initial quorum for supply queries before deployment.
+            // The denominator bound above makes the uint224 conversion safe.
+            _quorumNumeratorHistory._checkpoints.push(
+                QuorumCheckpoints.Checkpoint({
+                    _blockNumber: 0,
+                    _value: uint224(newQuorumNumerator)
+                })
+            );
+            quorumNumerator = newQuorumNumerator;
+        } else {
+            (oldQuorumNumerator, quorumNumerator) = _quorumNumeratorHistory
+                .push(newQuorumNumerator);
+        }
 
         emit QuorumNumeratorUpdated(oldQuorumNumerator, newQuorumNumerator);
     }

--- a/contracts/test/TestGovernorTestSet.sol
+++ b/contracts/test/TestGovernorTestSet.sol
@@ -137,7 +137,10 @@ contract TestGovernorParameters is GovernorParameters {
         virtual
         override
         returns (uint256)
-    {}
+    {
+        require(blockNumber < block.number, "Block not yet determined");
+        return FRACTION_DENOMINATOR;
+    }
 
     function _executor() internal view virtual override returns (address) {
         return executor;

--- a/test/governance/GovernorParameters.test.js
+++ b/test/governance/GovernorParameters.test.js
@@ -1,4 +1,5 @@
 const { expect } = require("chai")
+const { mineBlocks } = helpers.time
 
 describe("ParametersGovernor", () => {
   let executor
@@ -99,6 +100,88 @@ describe("ParametersGovernor", () => {
       await expect(
         tGov.connect(other).setVotingPeriod(1234)
       ).to.be.revertedWith("Governor: onlyGovernance")
+    })
+  })
+
+  describe("quorum history", () => {
+    it("preserves the initial quorum before deployment", async () => {
+      const { blockNumber } = await tGov.deployTransaction.wait()
+      expect(await tGov.quorum(blockNumber - 1)).to.equal(10)
+
+      await tGov.connect(executor).updateQuorumNumerator(100)
+      expect(await tGov.quorum(blockNumber - 1)).to.equal(10)
+      expect(await tGov.quorum(blockNumber)).to.equal(10)
+    })
+
+    it("uses the numerator at each historical block, including zero", async () => {
+      const updates = []
+      for (const numerator of [100, 0, 10000, 20]) {
+        const tx = await tGov.connect(executor).updateQuorumNumerator(numerator)
+        const { blockNumber } = await tx.wait()
+        updates.push({ blockNumber, numerator })
+        await mineBlocks(2)
+      }
+
+      expect(await tGov.quorum(updates[0].blockNumber - 1)).to.equal(10)
+      for (const { blockNumber, numerator } of updates) {
+        expect(await tGov.quorum(blockNumber)).to.equal(numerator)
+        expect(await tGov.quorum(blockNumber + 1)).to.equal(numerator)
+      }
+      expect(await tGov.quorumNumerator()).to.equal(20)
+    })
+
+    it("uses the final numerator when governance updates twice in one block", async () => {
+      const nonce = await executor.getTransactionCount()
+      let first
+      let second
+      await ethers.provider.send("evm_setAutomine", [false])
+      try {
+        first = await tGov.connect(executor).updateQuorumNumerator(100, {
+          nonce,
+          gasLimit: 300000,
+        })
+        second = await tGov.connect(executor).updateQuorumNumerator(0, {
+          nonce: nonce + 1,
+          gasLimit: 300000,
+        })
+        await ethers.provider.send("evm_mine", [])
+      } finally {
+        await ethers.provider.send("evm_setAutomine", [true])
+      }
+      const firstReceipt = await first.wait()
+      const secondReceipt = await second.wait()
+      expect(secondReceipt.blockNumber).to.equal(firstReceipt.blockNumber)
+      await mineBlocks(1)
+
+      expect(await tGov.quorum(firstReceipt.blockNumber - 1)).to.equal(10)
+      expect(await tGov.quorum(firstReceipt.blockNumber)).to.equal(0)
+      expect(await tGov.quorumNumerator()).to.equal(0)
+      await expect(second)
+        .to.emit(tGov, "QuorumNumeratorUpdated")
+        .withArgs(100, 0)
+    })
+
+    it("rejects an excessive numerator without changing quorum history", async () => {
+      const tx = await tGov.connect(executor).updateQuorumNumerator(10000)
+      const { blockNumber } = await tx.wait()
+      await expect(
+        tGov.connect(executor).updateQuorumNumerator(10001)
+      ).to.be.revertedWith("quorumNumerator > Denominator")
+      await mineBlocks(1)
+
+      expect(await tGov.quorumNumerator()).to.equal(10000)
+      expect(await tGov.quorum(blockNumber)).to.equal(10000)
+      expect(await tGov.quorum(blockNumber - 1)).to.equal(10)
+    })
+
+    it("preserves the supply provider's rejection of current and future blocks", async () => {
+      const blockNumber = await ethers.provider.getBlockNumber()
+      await expect(tGov.quorum(blockNumber)).to.be.revertedWith(
+        "Block not yet determined"
+      )
+      await expect(tGov.quorum(blockNumber + 1)).to.be.revertedWith(
+        "Block not yet determined"
+      )
     })
   })
 })

--- a/test/governance/TokenholderGovernor.test.js
+++ b/test/governance/TokenholderGovernor.test.js
@@ -160,6 +160,131 @@ describe("TokenholderGovernor", () => {
     })
   })
 
+  describe("quorum changes through governance", () => {
+    beforeEach(async () => {
+      await tToken.connect(holder).delegate(holder.address)
+      await tToken.connect(staker).delegate(staker.address)
+      await tToken.connect(holderWhale).delegate(holderWhale.address)
+    })
+
+    async function createProposal(target, calldata, proposalDescription) {
+      const calls = [[target], [0], [calldata]]
+      const hash = ethers.utils.id(proposalDescription)
+      const id = await tGov.hashProposal(...calls, hash)
+      await tGov.connect(holderWhale).propose(...calls, proposalDescription)
+      await mineBlocks(3)
+      return { id, args: [...calls, hash] }
+    }
+
+    async function updateQuorum(numerator) {
+      const calldata = tGov.interface.encodeFunctionData(
+        "updateQuorumNumerator",
+        [numerator]
+      )
+      const update = await createProposal(
+        tGov.address,
+        calldata,
+        `Set quorum numerator to ${numerator}`
+      )
+      await tGov.connect(holderWhale).castVote(update.id, Vote.Yea)
+      await mineBlocks(8)
+      await tGov.connect(bystander).queue(...update.args)
+      await increaseTime(minDelay + 1)
+      await tGov.connect(bystander).execute(...update.args)
+      expect(await tGov.quorumNumerator()).to.equal(numerator)
+    }
+
+    for (const withAbstention of [false, true]) {
+      context(
+        `with ${withAbstention ? "for and abstain" : "only for"} votes`,
+        () => {
+          it("cannot revive a defeated proposal after a quorum decrease, while new proposals use the decrease", async () => {
+            const calldata = tToken.interface.encodeFunctionData("transfer", [
+              recipient.address,
+              1,
+            ])
+            const oldProposal = await createProposal(
+              tToken.address,
+              calldata,
+              "Transfer with insufficient quorum"
+            )
+            const snapshot = await tGov.proposalSnapshot(oldProposal.id)
+            const originalQuorum = await tGov.quorum(snapshot)
+            await tGov.connect(holder).castVote(oldProposal.id, Vote.Yea)
+            if (withAbstention) {
+              await tGov.connect(staker).castVote(oldProposal.id, Vote.Meh)
+            }
+            await mineBlocks(8)
+            expect(await tGov.state(oldProposal.id)).to.equal(
+              ProposalStates.Defeated
+            )
+
+            await updateQuorum(withAbstention ? 20 : 10)
+
+            expect(await tGov.state(oldProposal.id)).to.equal(
+              ProposalStates.Defeated
+            )
+            expect(await tGov.quorum(snapshot)).to.equal(originalQuorum)
+            await expect(
+              tGov.connect(bystander).queue(...oldProposal.args)
+            ).to.be.revertedWith("Governor: proposal not successful")
+            await expect(
+              tGov.connect(bystander).execute(...oldProposal.args)
+            ).to.be.revertedWith("Governor: proposal not successful")
+
+            const newProposal = await createProposal(
+              tToken.address,
+              calldata,
+              "Transfer under the new quorum"
+            )
+            const newSnapshot = await tGov.proposalSnapshot(newProposal.id)
+            const newQuorum = await tGov.quorum(newSnapshot)
+            expect(newQuorum).to.equal(
+              expectedTotal.mul(withAbstention ? 20 : 10).div(10000)
+            )
+            await tGov.connect(holder).castVote(newProposal.id, Vote.Yea)
+            if (withAbstention) {
+              await tGov.connect(staker).castVote(newProposal.id, Vote.Meh)
+            }
+            await mineBlocks(8)
+            expect(await tGov.state(newProposal.id)).to.equal(
+              ProposalStates.Succeeded
+            )
+            await tGov.connect(bystander).queue(...newProposal.args)
+            await increaseTime(minDelay + 1)
+            await tGov.connect(bystander).execute(...newProposal.args)
+            expect(await tGov.state(newProposal.id)).to.equal(
+              ProposalStates.Executed
+            )
+            expect(await tToken.balanceOf(recipient.address)).to.equal(1)
+          })
+        }
+      )
+    }
+
+    it("preserves a queued proposal after a quorum increase", async () => {
+      const calldata = tToken.interface.encodeFunctionData("transfer", [
+        recipient.address,
+        1,
+      ])
+      const oldProposal = await createProposal(
+        tToken.address,
+        calldata,
+        "Transfer approved before the quorum increase"
+      )
+      await tGov.connect(holderWhale).castVote(oldProposal.id, Vote.Yea)
+      await mineBlocks(8)
+      await tGov.connect(bystander).queue(...oldProposal.args)
+
+      await updateQuorum(5000)
+
+      expect(await tGov.state(oldProposal.id)).to.equal(ProposalStates.Queued)
+      await tGov.connect(bystander).execute(...oldProposal.args)
+      expect(await tGov.state(oldProposal.id)).to.equal(ProposalStates.Executed)
+      expect(await tToken.balanceOf(recipient.address)).to.equal(1)
+    })
+  })
+
   describe("when all tokens are liquid", () => {
     context("...but nobody delegated their vote...", () => {
       it("proposal threshold is as expected", async () => {


### PR DESCRIPTION
Changing quorum currently recalculates old proposals using the latest numerator. An authorized reduction can revive a proposal that failed only for insufficient quorum; an increase can retroactively defeat a queued proposal. Checkpoint quorum numerators and read them at each proposal's snapshot so both governors preserve historical outcomes while future proposals use the updated requirement.

The existing public ABI, current-numerator getter, authorization, events, bounds, and predeployment query behavior are preserved. The implementation reuses the already-pinned OpenZeppelin Checkpoints library.

Addresses the custom-code counterpart of [Dependabot #26](https://github.com/threshold-network/solidity-contracts/security/dependabot/26), [CVE-2022-31198](https://github.com/OpenZeppelin/openzeppelin-contracts/security/advisories/GHSA-xrc4-737v-9q75). The operator independently confirmed no qualifying proposal is exploitable today. This is a source correction for future deployments; it does not alter the existing mainnet governor or automatically clear a package-version alert.

Stacked on #188 (`codex/187-slither-upgrade`, base `20a20d5`), which is stacked on #182. Merge in order: **#182 → #188 → this PR**, retargeting each dependent PR after its base merges. Slither 0.8.0 cannot parse the aliased Checkpoints import; the existing scanner upgrade provides Slither 0.11.6 while retaining the detector gate.

Validation:

- The original implementation fails all three new lifecycle regressions: for-only and for-plus-abstain proposal revival after a reduction, and retroactive defeat after an increase.
- The corrected implementation passes all **388 contract tests**, including historical/same-block updates, unchanged authorization, rejected queue/execute of defeated proposals, and successful future proposals under the new quorum.
- Build, typecheck, lint/formatting, local deployment, prepack, and diff checks pass. Both governor ABIs are unchanged.
- Independent candidate review found no concrete bypass or regression.
- CI passes on head `a2be670`: all 388 contract tests, formatting, deployment dry run, documentation preview, and Slither 0.11.6 (85 contracts, 95 detectors, zero findings). The baseline annotations come from #188; this PR adds no detector exclusions or suppressions.
