### PR TITLE
Patch retained tooling dependencies and check caller compatibility

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Build contracts
         run: yarn build
 
+      - name: Check tooling compatibility
+        run: yarn test:tooling
+
       - name: Run tests
         if: github.ref != 'refs/heads/dapp-development'
         run: yarn test

--- a/docs/dependency-security.adoc
+++ b/docs/dependency-security.adoc
@@ -1,0 +1,85 @@
+= Dependency security maintenance
+
+The development toolchain uses Node 22 and Yarn 1.22.22. Install with
+`yarn install --frozen-lockfile` so dependency versions match the reviewed lockfile.
+
+== Retained toolchain overrides
+
+Hardhat 2 and Ethers 5 remain in use. Some of their dependencies pin older
+release lines with security advisories. The `resolutions` entries select patched
+versions for the named callers; they do not change the Solidity compiler or the
+direct OpenZeppelin Solidity versions.
+
+[cols="2,1,3",options="header"]
+|===
+| Caller / dependency | Version | Compatibility boundary
+| Hardhat / undici | 6.28.1 | RPC pools, HTTP downloads and proxy connections
+| Hardhat / adm-zip | 0.6.1 | Compiler ZIP extraction
+| Ethers providers / ws | 8.21.1 | WebSocket RPC requests and subscriptions
+| hardhat-deploy, Tenderly plugin/CLI, OpenZeppelin platform deploy client / axios
+| 0.33.0 | Legacy CommonJS HTTP clients; Axios 1.x callers stay on 1.x
+| Mocha / serialize-javascript | 7.1.1 | Parallel worker options; requires Node >=20
+| Mocha / diff | 8.0.4 | Unified and inline assertion differences
+| qs | 6.16.0 | Express query/form parsing and deployment tooling
+| solc / tmp | 0.2.7 | SMT temporary-file lifecycle
+|===
+
+The lockfile also refreshes js-yaml within its existing major versions
+(3.15.2 and 4.3.2), Axios 1.x (1.20.0), body-parser (1.20.8), and fast-uri
+(3.1.7). Keeping both YAML majors preserves ESLint's `safeLoad`/`safeDump`
+API while retaining the newer callers' `load`/`dump` API.
+
+Yarn warns when a resolution is outside a caller's declared range. These are
+intentional overrides, backed by `yarn test:tooling`. That separate suite uses
+loopback servers and temporary fixtures to exercise the retained callers. It
+does not contact a blockchain RPC, explorer, or Tenderly service. CI runs it
+alongside the contract tests. The suite lives outside the Hardhat test directory
+because its Node test runner and Mocha's contract runner have separate lifecycles.
+
+When changing a parent package, review its dependency requirements, remove an
+override if the parent accepts the patched version itself, and rerun both
+`yarn test:tooling` and the normal build, test, formatting, deployment dry-run,
+and packaging checks. Do not replace all Axios or YAML instances with one major
+version merely to reduce the lockfile size.
+
+== Dependabot coverage as of 2026-09-11
+
+The dependency modernization in PR #182 plus these overrides removes affected
+versions for 147 of the 168 open alerts retrieved on that date. Every affected
+version range in each alert's advisory was checked, including alternative
+majors; replacing ws 7 with an affected ws 8 version is not counted as a fix.
+Counts are projected until GitHub analyzes the merged default branch.
+
+The 21 remaining package-version matches have the following dispositions:
+
+* OpenZeppelin alerts #19, #20, #21, #22, #23, #25, #26, #27, #28, #29,
+  #41, #42, #45, #46, #52, #53, #63 and #64 retain their version matches.
+  The reviewed deployed contracts lack the relevant Base64, ERC2771Context,
+  ERC165Checker, SignatureChecker or Bravo paths; their signature entrypoints
+  use explicit v/r/s with nonce or voter-based replay prevention. The checked
+  staking proxy and implementation have no relevant selector collisions.
+  The exception is #26: the custom `GovernorParameters` copied the historical
+  quorum bug and needs its own source correction. An npm update alone neither
+  repairs that local implementation nor changes deployed bytecode. The operator
+  confirmed that no qualifying proposal was exploitable at the time of review.
+* Cookie alert #85 affects serialization. The retained cookie 0.4.2 path is
+  Sentry's request-cookie parsing through `@sentry/utils`; its affected serializer
+  is not called. Express separately resolves cookie 0.7.2.
+* Elliptic alert #123 has no published patch beyond 6.6.1. Retained Ethers and
+  secp256k1 callers use secp256k1 and enforce a 32-byte message digest, so the
+  advisory's excess-bit truncation condition is not reached. This is a
+  caller-specific assessment, not a general claim that elliptic is safe.
+* UUID alert #202 affects v3/v5/v6 with a supplied output buffer. Hardhat only
+  calls `v4()` without arguments for analytics identifiers.
+
+These dispositions should be revisited when callers change. They are not a
+blanket dismissal of dependency alerts or downstream consumers. In particular,
+deployment tooling can handle credentials even though its JavaScript code is
+not part of deployed EVM bytecode.
+
+A fresh npm advisory check additionally verified the refreshed fast-uri, qs,
+diff and ws versions. The remaining GovernorCompatibilityBravo advisory is
+outside the imported contract paths. Registry malware matches for the names
+`eslint-config-keep` and `solhint-config-keep` refer to registry packages; this
+lockfile resolves the existing GitHub commits, whose source provenance must be
+considered separately. PR #194 already vendors those configurations.

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:js": "eslint . ",
     "lint:sol": "solhint 'contracts/**/*.sol'",
     "test": "hardhat test",
+    "test:tooling": "node --test test-tooling/dependencies.cjs",
     "test:system": "NODE_ENV=system-test hardhat test ./test/system/*.test.js",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "prepack": "tsc -p tsconfig.export.json && hardhat export-artifacts export/artifacts",
@@ -62,5 +63,18 @@
     "@openzeppelin/contracts": "~4.5.0",
     "@openzeppelin/contracts-upgradeable": "~4.5.2",
     "@thesis/solidity-contracts": "github:thesis/solidity-contracts#4985bcf"
+  },
+  "resolutions": {
+    "**/@ethersproject/providers/ws": "8.21.1",
+    "**/@openzeppelin/platform-deploy-client/axios": "0.33.0",
+    "**/@tenderly/hardhat-tenderly/axios": "0.33.0",
+    "**/hardhat-deploy/axios": "0.33.0",
+    "**/hardhat/adm-zip": "0.6.1",
+    "**/hardhat/undici": "6.28.1",
+    "**/mocha/diff": "8.0.4",
+    "**/mocha/serialize-javascript": "7.1.1",
+    "**/qs": "6.16.0",
+    "**/solc/tmp": "0.2.7",
+    "**/tenderly/axios": "0.33.0"
   }
 }

--- a/test-tooling/dependencies.cjs
+++ b/test-tooling/dependencies.cjs
@@ -1,0 +1,461 @@
+// Integration checks for overridden dependencies and their retained callers.
+// All network peers and fixtures are local; no chain or service credentials are used.
+const assert = require("node:assert/strict")
+const fs = require("node:fs")
+const http = require("node:http")
+const net = require("node:net")
+const os = require("node:os")
+const path = require("node:path")
+const { createRequire } = require("node:module")
+const { once } = require("node:events")
+const { test } = require("node:test")
+
+// Resolve from the caller, so a hoisted copy cannot hide a broken nested override.
+const fromPackage = (name) =>
+  createRequire(require.resolve(`${name}/package.json`))
+const hardhatRequire = fromPackage("hardhat")
+const { Pool, ProxyAgent, request } = hardhatRequire("undici")
+const { HttpProvider } = require("hardhat/internal/core/providers/http")
+
+function fixtureDirectory(t) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "tooling-compat-"))
+  t.after(() => fs.rmSync(directory, { recursive: true, force: true }))
+  return directory
+}
+
+async function localServer(t, handler) {
+  const server = http.createServer(handler)
+  const sockets = new Set()
+  server.on("connection", (socket) => {
+    sockets.add(socket)
+    socket.on("close", () => sockets.delete(socket))
+  })
+  t.after(async () => {
+    const closed = new Promise((resolve) => server.close(resolve))
+    for (const socket of sockets) socket.destroy()
+    await closed
+  })
+  server.listen(0, "127.0.0.1")
+  await once(server, "listening")
+  return { server, url: `http://127.0.0.1:${server.address().port}` }
+}
+
+function jsonResponse(response, value, statusCode = 200) {
+  response.writeHead(statusCode, { "content-type": "application/json" })
+  response.end(JSON.stringify(value))
+}
+
+function rpcResult(payload) {
+  if (payload.method === "test_error") {
+    return {
+      jsonrpc: "2.0",
+      id: payload.id,
+      error: {
+        code: -32001,
+        message: "fixture failure",
+        data: "fixture detail",
+      },
+    }
+  }
+  return { jsonrpc: "2.0", id: payload.id, result: payload.params[0] }
+}
+
+test(
+  "Hardhat HTTP provider preserves RPC, reused connections, batches and errors",
+  { timeout: 10000 },
+  async (t) => {
+    const sockets = new Set()
+    const { url } = await localServer(t, (incoming, response) => {
+      sockets.add(incoming.socket)
+      let body = ""
+      incoming.on("data", (chunk) => {
+        body += chunk
+      })
+      incoming.on("end", () => {
+        const payload = JSON.parse(body)
+        jsonResponse(
+          response,
+          Array.isArray(payload)
+            ? payload.map(rpcResult).reverse()
+            : rpcResult(payload)
+        )
+      })
+    })
+    const pool = new Pool(url, { connections: 1 })
+    t.after(() => pool.destroy())
+    const provider = new HttpProvider(`${url}/rpc`, "fixture", {}, 2000, pool)
+    assert.deepEqual(
+      await provider.request({ method: "echo", params: [{ value: 1 }] }),
+      { value: 1 }
+    )
+    assert.equal(
+      await provider.request({ method: "echo", params: ["second"] }),
+      "second"
+    )
+    assert.deepEqual(
+      await provider.sendBatch([
+        { method: "echo", params: ["first"] },
+        { method: "echo", params: ["second"] },
+      ]),
+      ["first", "second"]
+    )
+    await assert.rejects(
+      provider.request({ method: "test_error" }),
+      (error) => {
+        assert.equal(error.code, -32001)
+        assert.equal(error.message, "fixture failure")
+        assert.equal(error.data, "fixture detail")
+        return true
+      }
+    )
+    assert.equal(
+      sockets.size,
+      1,
+      "sequential RPC calls should reuse the connection"
+    )
+  }
+)
+
+test(
+  "Hardhat downloader follows redirects, preserves bytes and reports HTTP errors",
+  { timeout: 10000 },
+  async (t) => {
+    const { download } = require("hardhat/internal/util/download")
+    const bytes = Buffer.from([0, 1, 2, 128, 255, 10])
+    let receivedHeader
+    const { url } = await localServer(t, (incoming, response) => {
+      if (incoming.url === "/redirect") {
+        response.writeHead(302, { location: "/compiler" })
+        response.end()
+      } else if (incoming.url === "/compiler") {
+        receivedHeader = incoming.headers["x-fixture"]
+        response.end(bytes)
+      } else {
+        response.writeHead(404)
+        response.end("missing fixture")
+      }
+    })
+    const directory = fixtureDirectory(t)
+    const output = path.join(directory, "nested", "compiler")
+    await download(`${url}/redirect`, output, 2000, { "x-fixture": "download" })
+    assert.deepEqual(fs.readFileSync(output), bytes)
+    assert.equal(receivedHeader, "download")
+    const missingOutput = path.join(directory, "missing")
+    await assert.rejects(
+      download(`${url}/missing`, missingOutput, 2000),
+      /404.*missing fixture/
+    )
+    assert.equal(fs.existsSync(missingOutput), false)
+  }
+)
+
+test(
+  "Undici ProxyAgent carries a request through a localhost CONNECT tunnel",
+  { timeout: 10000 },
+  async (t) => {
+    const target = await localServer(t, (incoming, response) => {
+      jsonResponse(response, {
+        path: incoming.url,
+        header: incoming.headers["x-fixture"],
+      })
+    })
+    const proxy = await localServer(t)
+    const tunnels = new Set()
+    const authorities = []
+    proxy.server.on("connect", (incoming, client, head) => {
+      authorities.push(incoming.url)
+      // The destination is fixed to our fixture, never derived from request input.
+      const upstream = net.connect(
+        target.server.address().port,
+        "127.0.0.1",
+        () => {
+          client.write("HTTP/1.1 200 Connection Established\r\n\r\n")
+          if (head.length) upstream.write(head)
+          client.pipe(upstream)
+          upstream.pipe(client)
+        }
+      )
+      tunnels.add(upstream)
+      upstream.on("close", () => tunnels.delete(upstream))
+      upstream.on("error", () => client.destroy())
+      client.on("error", () => upstream.destroy())
+      client.on("close", () => upstream.destroy())
+    })
+    const dispatcher = new ProxyAgent(proxy.url)
+    t.after(async () => {
+      for (const socket of tunnels) socket.destroy()
+      await dispatcher.destroy()
+    })
+    const response = await request(`${target.url}/proxied`, {
+      dispatcher,
+      headersTimeout: 2000,
+      headers: { "x-fixture": "proxy" },
+    })
+    assert.equal(response.statusCode, 200)
+    assert.deepEqual(await response.body.json(), {
+      path: "/proxied",
+      header: "proxy",
+    })
+    assert.deepEqual(authorities, [new URL(target.url).host])
+  }
+)
+
+test("Hardhat's ZIP dependency extracts a valid compiler-style archive", (t) => {
+  const AdmZip = hardhatRequire("adm-zip")
+  const directory = fixtureDirectory(t)
+  const archive = new AdmZip()
+  const binary = Buffer.from([77, 90, 0, 255, 1, 2])
+  archive.addFile("solc.exe", binary)
+  archive.addFile("licenses/compiler.txt", Buffer.from("fixture license\n"))
+  const archivePath = path.join(directory, "compiler.zip")
+  archive.writeZip(archivePath)
+  const output = path.join(directory, "extracted")
+  new AdmZip(archivePath).extractAllTo(output)
+  assert.deepEqual(fs.readFileSync(path.join(output, "solc.exe")), binary)
+  assert.equal(
+    fs.readFileSync(path.join(output, "licenses/compiler.txt"), "utf8"),
+    "fixture license\n"
+  )
+})
+
+test(
+  "Mocha passes RegExp and timing options through its actual worker serializer",
+  { timeout: 10000 },
+  async (t) => {
+    const { BufferedWorkerPool } = hardhatRequire(
+      "mocha/lib/nodejs/buffered-worker-pool"
+    )
+    const directory = fixtureDirectory(t)
+    const fixture = path.join(directory, "options.cjs")
+    fs.writeFileSync(
+      fixture,
+      `
+    const assert = require("node:assert/strict")
+    it("retained option fixture", function () {
+      assert.equal(this.timeout(), 1234)
+      assert.equal(this.slow(), 87)
+    })
+    it("excluded option fixture", function () {
+      throw new Error("grep option was not preserved")
+    })
+  `
+    )
+    const pool = BufferedWorkerPool.create({
+      maxWorkers: 1,
+      forkOpts: { execArgv: [] },
+    })
+    t.after(() => pool.terminate(true))
+    const result = await pool.run(fixture, {
+      grep: /^RETAINED/i,
+      timeout: 1234,
+      slow: 87,
+      reporter: hardhatRequire.resolve(
+        "mocha/lib/nodejs/reporters/parallel-buffered"
+      ),
+    })
+    assert.equal(result.failureCount, 0)
+    assert.equal(
+      result.events.filter((event) => event.eventName === "pass").length,
+      1
+    )
+  }
+)
+
+test("solc's tmp.fileSync preserves the SMT file lifecycle", (t) => {
+  const tmp = fromPackage("solc")("tmp")
+  const file = tmp.fileSync({ postfix: ".smt2" })
+  t.after(() => file.removeCallback())
+  assert.equal(path.extname(file.name), ".smt2")
+  assert.equal(typeof file.fd, "number")
+  fs.writeFileSync(file.name, "(check-sat)\n")
+  assert.equal(fs.readFileSync(file.name, "utf8"), "(check-sat)\n")
+  file.removeCallback()
+  assert.equal(fs.existsSync(file.name), false)
+})
+
+test("Mocha renders assertion differences with unified and inline diff APIs", () => {
+  const Base = hardhatRequire("mocha/lib/reporters/base")
+  const { useColors, inlineDiffs } = Base
+  try {
+    Base.useColors = false
+    Base.inlineDiffs = false
+    const unified = Base.generateDiff("keep\nold\n", "keep\nnew\n")
+    assert.match(unified, /-old/)
+    assert.match(unified, /\+new/)
+    Base.inlineDiffs = true
+    const inline = Base.generateDiff("a red item", "a blue item")
+    assert.match(inline, /red/)
+    assert.match(inline, /blue/)
+    assert.match(inline, /item/)
+  } finally {
+    Base.useColors = useColors
+    Base.inlineDiffs = inlineDiffs
+  }
+})
+
+for (const caller of [
+  "hardhat-deploy",
+  "@tenderly/hardhat-tenderly",
+  "tenderly",
+  "@openzeppelin/platform-deploy-client",
+]) {
+  test(
+    `${caller}'s axios preserves JSON POST redirects and response errors`,
+    { timeout: 10000 },
+    async (t) => {
+      const axios = fromPackage(caller)("axios")
+      const { url } = await localServer(t, (incoming, response) => {
+        if (incoming.url === "/redirect") {
+          response.writeHead(307, { location: "/echo" })
+          incoming.resume()
+          response.end()
+        } else if (incoming.url === "/forbidden") {
+          jsonResponse(response, { error: "fixture denial" }, 403)
+        } else {
+          let body = ""
+          incoming.on("data", (chunk) => {
+            body += chunk
+          })
+          incoming.on("end", () =>
+            jsonResponse(response, {
+              method: incoming.method,
+              body: JSON.parse(body),
+              header: incoming.headers["x-fixture"],
+            })
+          )
+        }
+      })
+      const client = axios.create({ baseURL: url, timeout: 2000, proxy: false })
+      const response = await client.post(
+        "/redirect",
+        { contract: "fixture", value: 7 },
+        {
+          headers: { "x-fixture": caller },
+          maxRedirects: 3,
+        }
+      )
+      assert.deepEqual(response.data, {
+        method: "POST",
+        body: { contract: "fixture", value: 7 },
+        header: caller,
+      })
+      await assert.rejects(client.get("/forbidden"), (error) => {
+        assert.equal(axios.isAxiosError(error), true)
+        assert.equal(error.response.status, 403)
+        assert.deepEqual(error.response.data, { error: "fixture denial" })
+        return true
+      })
+    }
+  )
+}
+
+test(
+  "ethers WebSocketProvider exchanges RPC requests and block subscriptions",
+  { timeout: 10000 },
+  async (t) => {
+    const providersRequire = fromPackage("@ethersproject/providers")
+    const { WebSocketServer } = providersRequire("ws")
+    const { WebSocketProvider } = require("@ethersproject/providers")
+    const fixture = await localServer(t)
+    const server = new WebSocketServer({ server: fixture.server })
+    t.after(() => {
+      for (const socket of server.clients) socket.terminate()
+      return new Promise((resolve) => server.close(resolve))
+    })
+    let subscribed
+    const subscription = new Promise((resolve) => {
+      subscribed = resolve
+    })
+    server.on("connection", (socket) => {
+      socket.on("message", (message) => {
+        const payload = JSON.parse(message.toString())
+        let result
+        if (payload.method === "eth_chainId") result = "0x539"
+        else if (payload.method === "eth_blockNumber") result = "0x7b"
+        else if (payload.method === "eth_subscribe")
+          result = "fixture-subscription"
+        else if (payload.method === "eth_unsubscribe") result = true
+        else {
+          socket.send(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: payload.id,
+              error: { code: -32601, message: "fixture unknown method" },
+            })
+          )
+          return
+        }
+        socket.send(JSON.stringify({ jsonrpc: "2.0", id: payload.id, result }))
+        if (payload.method === "eth_subscribe") subscribed(socket)
+      })
+    })
+    const provider = new WebSocketProvider(fixture.url.replace("http:", "ws:"))
+    t.after(() => provider.destroy())
+    assert.equal((await provider.getNetwork()).chainId, 1337)
+    assert.equal(await provider.getBlockNumber(), 123)
+    await assert.rejects(
+      provider.send("fixture_unknown", []),
+      (error) => error.code === -32601
+    )
+    const block = new Promise((resolve) => provider.once("block", resolve))
+    const socket = await subscription
+    // A subsequent RPC response confirms the subscription response was consumed.
+    await provider.send("eth_blockNumber", [])
+    socket.send(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        method: "eth_subscription",
+        params: {
+          subscription: "fixture-subscription",
+          result: { number: "0x7c" },
+        },
+      })
+    )
+    assert.equal(await block, 124)
+  }
+)
+
+test(
+  "Tenderly's Express parses nested queries and URL-encoded form bodies",
+  { timeout: 10000 },
+  async (t) => {
+    const express = fromPackage("tenderly")("express")
+    const app = express()
+    app.set("query parser", "extended")
+    app.use(express.urlencoded({ extended: true }))
+    app.get("/", (incoming, response) => response.json(incoming.query))
+    app.post("/", (incoming, response) => response.json(incoming.body))
+    const { url } = await localServer(t, app)
+    const dispatcher = new Pool(url, { connections: 1 })
+    t.after(() => dispatcher.destroy())
+    const encoded = "project[name]=fixture&tags[]=alpha&tags[]=beta"
+    const expected = { project: { name: "fixture" }, tags: ["alpha", "beta"] }
+    const query = await request(`${url}/?${encoded}`, { dispatcher })
+    assert.equal(query.statusCode, 200)
+    assert.deepEqual(await query.body.json(), expected)
+    const form = await request(`${url}/`, {
+      dispatcher,
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: encoded,
+    })
+    assert.equal(form.statusCode, 200)
+    assert.deepEqual(await form.body.json(), expected)
+  }
+)
+
+test("ESLint and Tenderly retain their respective YAML load/dump APIs", () => {
+  const yaml3 = fromPackage("eslint")("js-yaml")
+  const yaml4 = fromPackage("@tenderly/hardhat-tenderly")("js-yaml")
+  const source =
+    "defaults: &defaults\n  timeout: 60000\njob:\n  <<: *defaults\n  network: fixture\n"
+  for (const [load, dump] of [
+    [yaml3.safeLoad, yaml3.safeDump],
+    [yaml4.load, yaml4.dump],
+  ]) {
+    const config = load(source)
+    assert.deepEqual(config.job, { timeout: 60000, network: "fixture" })
+    assert.deepEqual(load(dump(config)), config)
+    assert.throws(() => load("value: [unterminated"))
+  }
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -458,11 +458,6 @@
     "@ethersproject/properties" "^5.8.0"
     "@ethersproject/strings" "^5.8.0"
 
-"@fastify/busboy@^2.0.0":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.1.tgz#b9da6a878a371829a0502c9b6c1c143ef6663f4d"
-  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
-
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -1079,10 +1074,10 @@ acorn@^8.11.0, acorn@^8.4.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.18.0.tgz#4faf01b2d6d326bfeed97aea1f52220b5f4c1940"
   integrity sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==
 
-adm-zip@^0.4.16:
-  version "0.4.16"
-  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.4.16.tgz#cf4c508fdffab02c269cbc7f471a875f05570365"
-  integrity sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==
+adm-zip@0.6.1, adm-zip@^0.4.16:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.6.1.tgz#5b95da4a6e7af0663b71457c06e1517fa6ac8d5f"
+  integrity sha512-Xwrja8nx9e5o2N1my4DsKCeKpdrnACyr1wtbPxBDgGzKzKyE9kRtBFA8mWldI+RVlD7CBZNWY/wQ2+ydwOR6kQ==
 
 aes-js@3.0.0:
   version "3.0.0"
@@ -1262,25 +1257,19 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-axios@^0.21.1, axios@^0.21.2:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
+axios@0.33.0, axios@^0.21.1, axios@^0.21.2, axios@^0.27.2:
+  version "0.33.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.33.0.tgz#91fc5e231db5b81ab6474c0a945a603c55601f6e"
+  integrity sha512-juz19g7B3UWT9r3+tgRFQf2Bdy6IKDVroiyuVOUrkILVKHpqHL++K1l8ybvfdEP9B/VE72vk8vllbnedVCm/og==
   dependencies:
-    follow-redirects "^1.14.0"
-
-axios@^0.27.2:
-  version "0.27.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
-  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
-  dependencies:
-    follow-redirects "^1.14.9"
-    form-data "^4.0.0"
+    follow-redirects "^1.15.4"
+    form-data "^4.0.4"
+    proxy-from-env "^1.1.0"
 
 axios@^1.4.0, axios@^1.6.7:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.19.0.tgz#ddf864d4c8233c0e6873746ab59361537d05ad39"
-  integrity sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.20.0.tgz#515513445aa60e71d04b6521ca6210829ccb4786"
+  integrity sha512-r8aOh8j9cGKpgQAqpzrUHnSIc6a59Y3Xf/cv8sy1DrHCkZHzQGEuoq1tARk6qSyDdtQGSDgpb9kFlruzPvrgwg==
   dependencies:
     follow-redirects "^1.16.0"
     form-data "^4.0.6"
@@ -1340,9 +1329,9 @@ bn.js@^5.1.2, bn.js@^5.2.0, bn.js@^5.2.1:
   integrity sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==
 
 body-parser@~1.20.5:
-  version "1.20.6"
-  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.6.tgz#60c789c78e0992d906da0a29d71ae01d15c1ed76"
-  integrity sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==
+  version "1.20.8"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.8.tgz#328d51ce46cb19c983f3d9661016df2765283a37"
+  integrity sha512-JNcyFQ64OiijEkPzUBTCe+hyPXUD/3LEldGQ6iF5LR1w00mx9o7xtDWHXBY2iItjdCFGoilOLNQbH943ut7pHA==
   dependencies:
     bytes "~3.1.2"
     content-type "~1.0.5"
@@ -1352,7 +1341,7 @@ body-parser@~1.20.5:
     http-errors "~2.0.1"
     iconv-lite "~0.4.24"
     on-finished "~2.4.1"
-    qs "~6.15.1"
+    qs "~6.16.0"
     raw-body "~2.5.3"
     type-is "~1.6.18"
     unpipe "~1.0.0"
@@ -1828,15 +1817,15 @@ destroy@1.2.0, destroy@~1.2.0:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
+diff@8.0.4, diff@^7.0.0:
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.4.tgz#4f5baf3188b9b2431117b962eb20ba330fadf696"
+  integrity sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==
+
 diff@^4.0.1:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.4.tgz#7a6dbfda325f25f07517e9b518f897c08332e07d"
   integrity sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==
-
-diff@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-7.0.0.tgz#3fb34d387cd76d803f6eebea67b921dab0182a9a"
-  integrity sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -2286,9 +2275,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fdir@^6.5.0:
   version "6.5.0"
@@ -2356,7 +2345,7 @@ fmix@^0.1.0:
   dependencies:
     imul "^1.0.0"
 
-follow-redirects@^1.12.1, follow-redirects@^1.14.0, follow-redirects@^1.14.9, follow-redirects@^1.16.0:
+follow-redirects@^1.12.1, follow-redirects@^1.15.4, follow-redirects@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
@@ -2376,7 +2365,7 @@ foreground-child@^3.1.0:
     cross-spawn "^7.0.6"
     signal-exit "^4.0.1"
 
-form-data@^4.0.0, form-data@^4.0.6:
+form-data@^4.0.0, form-data@^4.0.4, form-data@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
   integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
@@ -2953,17 +2942,17 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.1.tgz#24bc95028f361cdaaa84745b06a109c4486773c0"
-  integrity sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.15.2.tgz#3f83823ac6be17f570f23b2ecdef3777ff5ea364"
+  integrity sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
 js-yaml@^4.1.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.1.tgz#01216c001d67f48e2cd560d708c7af21090a3848"
-  integrity sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.3.2.tgz#8e44fb14a2643c59726bb15787b5f1512cb3d3fb"
+  integrity sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==
   dependencies:
     argparse "^2.0.1"
 
@@ -3386,11 +3375,6 @@ ordinal@^1.0.3:
   resolved "https://registry.yarnpkg.com/ordinal/-/ordinal-1.0.3.tgz#1a3c7726a61728112f50944ad7c35c06ae3a0d4d"
   integrity sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ==
 
-os-tmpdir@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
-
 ox@0.14.33:
   version "0.14.33"
   resolved "https://registry.yarnpkg.com/ox/-/ox-0.14.33.tgz#977ab8c0692fa9240444d7db88ca026f19f81e28"
@@ -3609,6 +3593,11 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
 proxy-from-env@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
@@ -3619,10 +3608,10 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
-qs@^6.9.4, qs@~6.15.1:
-  version "6.15.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.3.tgz#76852132a58ed5c7c0ef67e4441b9bb5d6061b3b"
-  integrity sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==
+qs@6.16.0, qs@^6.9.4, qs@~6.15.1, qs@~6.16.0:
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.16.0.tgz#c22c723a28a920f3aacdce8289fabd43eccb79fd"
+  integrity sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==
   dependencies:
     es-define-property "^1.0.1"
     side-channel "^1.1.1"
@@ -3810,12 +3799,10 @@ send@~0.19.0, send@~0.19.1:
     range-parser "~1.2.1"
     statuses "~2.0.2"
 
-serialize-javascript@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-6.0.2.tgz#defa1e055c83bf6d59ea805d8da862254eb6a6c2"
-  integrity sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==
-  dependencies:
-    randombytes "^2.1.0"
+serialize-javascript@7.1.1, serialize-javascript@^6.0.2:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-7.1.1.tgz#c3b0a7ac13df6cf2fcda71cbb142ba9392a710b9"
+  integrity sha512-k3CMsaIvvdSwm8oLB4MXSl0wH2/cwlH7xGcnRd2DaeRmBkbzYmyT8j0tsX60DwD1eRwHTpNpH8ljKu9oUT1MeQ==
 
 serve-static@~1.16.2:
   version "1.16.3"
@@ -4159,12 +4146,10 @@ tinyglobby@^0.2.6:
     fdir "^6.5.0"
     picomatch "^4.0.4"
 
-tmp@0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
-  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
-  dependencies:
-    os-tmpdir "~1.0.2"
+tmp@0.0.33, tmp@0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
+  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
 
 to-buffer@^1.2.0, to-buffer@^1.2.1, to-buffer@^1.2.2:
   version "1.2.2"
@@ -4295,12 +4280,10 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@^5.14.0:
-  version "5.29.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-5.29.0.tgz#419595449ae3f2cdcba3580a2e8903399bd1f5a3"
-  integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
-  dependencies:
-    "@fastify/busboy" "^2.0.0"
+undici@6.28.1, undici@^5.14.0:
+  version "6.28.1"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.1.tgz#aa9d2c44aef3840bef80216f2a50f337543a3fbd"
+  integrity sha512-zWpdTVD54H48CIybL0rWQ3ukpb9d23wM7eH5RtfdmeP70cWHNjtfo7P4vZX+5CoDcO53J4Pu5uXp7lNfjc6DRA==
 
 unfetch@^4.2.0:
   version "4.2.0"
@@ -4460,10 +4443,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@8.18.0:
-  version "8.18.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
-  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+ws@8.18.0, ws@8.21.1:
+  version "8.21.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.21.1.tgz#045650cd4b1207809e7547146223c3814a9af586"
+  integrity sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==
 
 ws@8.21.0:
   version "8.21.0"


### PR DESCRIPTION
Patch advisory-affected dependencies that remain after #182 while retaining Hardhat 2 and Ethers 5. Use caller-scoped overrides for the legacy Axios clients, Hardhat HTTP/ZIP dependencies, Ethers WebSockets, Mocha serialization/diffs, and solc temporary files; update both YAML majors and the compatible parser dependencies. Axios 1.x callers remain on 1.x and ESLint retains YAML 3's API.

Add a separate local compatibility suite and run it in CI. It exercises actual Hardhat RPC/download paths and proxy connections, Ethers WebSocket requests/subscriptions, Mocha workers and assertion diffs, ZIP extraction, temporary files, the four legacy Axios callers, Express query/form parsing, and both YAML APIs.

Stacked on #182 (`chore/dependency-toolchain-refresh`, base `14843ac`). Merge #182 first, then retarget this PR to `main`. It is independent of the governance source fix in #196.

Security coverage:

- Together with #182, the resulting lockfile removes affected versions for **147 of the 168 open Dependabot alerts** retrieved on 2026-09-11. This checks every affected range within each advisory, including alternative ws major versions, rather than only each alert's original range.
- The 21 remaining version matches are documented in `docs/dependency-security.adoc`: 18 Solidity-library matches, cookie serialization unused by the retained Sentry parser, UUID buffer APIs unused by Hardhat's `v4()`, and the unpatched elliptic truncation issue whose preconditions are absent from the retained secp256k1/32-byte signing callers. #26's custom quorum logic is addressed separately by #196; this PR does not change Solidity dependencies.
- A fresh npm advisory check additionally covers the fast-uri, qs, diff and ws versions. Registry malware name matches for the existing GitHub-sourced lint configurations are separated by source provenance; their vendoring already has PR #194.
- Alert counts are projected until the stack is merged and GitHub analyzes the default branch. No alerts were dismissed.

Validation:

- Frozen install; build; typecheck and full lint/formatting; **380 contract tests** and **14 tooling integration tests** pass on Node 22.
- Creation/runtime bytecode and link references are identical to #182 for all **25 deployable local artifacts**.
- Local deployment, prepack, npm publication **dry run** using committed mainnet artifacts, and generation of 17 documentation pages pass. No publication or public-network deployment occurred.
- Actionlint and diff checks pass. Independent review found no concrete bypass/regression and additionally checked multipart Sourcify submission, Hardhat's alternate HTTP client, and AJV reference resolution using local fixtures.
- ZIP API compatibility was exercised with a fixture on macOS; a native Windows run was not performed.

CI passes on head `a6029c0`: all 380 contract tests and 14 tooling integration tests, formatting, deployment dry run, documentation preview, and Slither.
